### PR TITLE
Added options to control which link types are autolinked

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -2,23 +2,23 @@
  * @class Autolinker
  * @extends Object
  * @singleton
- *
+ * 
  * Singleton class which exposes the {@link #link} method, used to process a given string of text,
  * and wrap the URLs, email addresses, and Twitter handles in the appropriate anchor (&lt;a&gt;) tags.
  */
 var Autolinker = {
-
+	
 	// NOTE: The matcherRegex will be included after the class, from the compiled regex source
-
-
+	
+	
 	/**
 	 * @private
 	 * @property {RegExp} htmlRegex
-	 *
+	 * 
 	 * A regular expression used to pull out HTML tags from a string.
-	 *
+	 * 
 	 * Capturing groups:
-	 *
+	 * 
 	 * 1. If it is an end tag, this group will have the '/'.
 	 * 2. The tag name.
 	 */
@@ -28,26 +28,26 @@ var Autolinker = {
 	/**
 	 * @private
 	 * @property {RegExp} prefixRegex
-	 *
+	 * 
 	 * A regular expression used to remove the 'http://' or 'https://' and/or the 'www.' from URLs.
 	 */
 	prefixRegex: /^(https?:\/\/)?(www\.)?/,
-
-
+	
+	
 	/**
-	 * Automatically links URLs, email addresses, and Twitter handles found in the given chunk of HTML.
+	 * Automatically links URLs, email addresses, and Twitter handles found in the given chunk of HTML. 
 	 * Does not link URLs found within HTML tags.
-	 *
+	 * 
 	 * For instance, if given the text: `You should go to http://www.yahoo.com`, then the result
 	 * will be `You should go to &lt;a href="http://www.yahoo.com"&gt;http://www.yahoo.com&lt;/a&gt;`
-	 *
+	 * 
 	 * @method link
 	 * @param {String} html The HTML text to link URLs within.
 	 * @param {Object} [options] Any options for the autolinking, specified in an object. It may have the following properties:
 	 * @param {Boolean} [options.newWindow=true] True if the links should open in a new window, false otherwise.
 	 * @param {Boolean} [options.stripPrefix=true] True if 'http://' or 'https://' and/or the 'www.' should be stripped from the beginning of links, false otherwise.
 	 * @param {Number} [options.truncate] A number for how many characters long URLs/emails/twitter handles should be truncated to
-	 *   inside the text of a link. If the URL/email/twitter is over the number of characters, it will be truncated to this length by
+	 *   inside the text of a link. If the URL/email/twitter is over the number of characters, it will be truncated to this length by 
 	 *   adding a two period ellipsis ('..') into the middle of the string.
 	 *   Ex: a url like 'http://www.yahoo.com/some/long/path/to/a/file' truncated to 25 characters might look like this: 'http://www...th/to/a/file'
      * @param {Boolean} [options.twitter=true] True if Twitter handles ("@example") should be automatically linked.
@@ -57,7 +57,7 @@ var Autolinker = {
 	 */
 	link : function( html, options ) {
 		options = options || {};
-
+		
 		var htmlRegex = Autolinker.htmlRegex,         // full path for friendly
 		    matcherRegex = Autolinker.matcherRegex,   // out-of-scope calls
 		    newWindow = ( 'newWindow' in options ) ? options.newWindow : true,  // defaults to true
@@ -66,12 +66,12 @@ var Autolinker = {
             enableTwitter = ( 'twitter' in options ) ? options.twitter : true,  // defaults to true
             enableEmailAddresses = ( 'email' in options ) ? options.email : true,  // defaults to true
             enableUrls = ( 'urls' in options ) ? options.urls : true,  // defaults to true
-		    currentResult,
+		    currentResult, 
 		    lastIndex = 0,
 		    inBetweenTagsText,
 		    resultHtml = "",
 		    anchorTagStackCount = 0;
-
+		
 		// Function to process the text that lies between HTML tags. This function does the actual wrapping of
 		// URLs with anchor tags.
 		function autolinkText( text ) {
@@ -81,12 +81,12 @@ var Autolinker = {
 				    twitterHandle = $3,  // The actual twitterUser (i.e the word after the @ sign in a Twitter handle match)
 				    emailAddress = $4,   // For both determining if it is an email address, and stores the actual email address
                     urlMatch = $5,       // The matched URL string
-
+				    
 				    prefixStr = "",      // A string to use to prefix the anchor tag that is created. This is needed for the Twitter handle match
 				    suffixStr = "",      // A string to suffix the anchor tag that is created. This is used if there is a trailing parenthesis that should not be auto-linked.
-
+				    
 				    anchorAttributes = [];
-
+				
 				// Handle a closing parenthesis at the end of the match, and exclude it if there is not a matching open parenthesis
 				// in the match. This handles cases like the string "wikipedia.com/something_(disambiguation)" (which should be auto-
 				// linked, and when it is enclosed in parenthesis itself, such as: "(wikipedia.com/something_(disambiguation))" (in
@@ -97,14 +97,14 @@ var Autolinker = {
 					    closeParensMatch = matchStr.match( /\)/g ),
 					    numOpenParens = ( openParensMatch && openParensMatch.length ) || 0,
 					    numCloseParens = ( closeParensMatch && closeParensMatch.length ) || 0;
-
+					
 					if( numOpenParens < numCloseParens ) {
 						matchStr = matchStr.substr( 0, matchStr.length - 1 );  // remove the trailing ")"
 						suffixStr = ")";  // this will be added after the <a> tag
 					}
 				}
-
-
+				
+				
 				var anchorHref = matchStr,  // initialize both of these
 				    anchorText = matchStr;  // values as the full match
 
@@ -112,18 +112,18 @@ var Autolinker = {
                     // A disabled link type
                     return prefixStr + anchorText + suffixStr;
                 }
-
+				
 				// Process the urls that are found. We need to change URLs like "www.yahoo.com" to "http://www.yahoo.com" (or the browser
 				// will try to direct the user to "http://jux.com/www.yahoo.com"), and we need to prefix 'mailto:' to email addresses.
 				if( twitterMatch ) {
 					prefixStr = twitterHandlePrefixWhitespaceChar;
 					anchorHref = 'https://twitter.com/' + twitterHandle;
 					anchorText = '@' + twitterHandle;
-
+				
 				} else if( emailAddress ) {
 					anchorHref = 'mailto:' + emailAddress;
 					anchorText = emailAddress;
-
+				
 				} else if( !/^[A-Za-z]{3,9}:/i.test( anchorHref ) ) {  // string doesn't begin with a protocol, add http://
 					anchorHref = 'http://' + anchorHref;
 				}
@@ -136,60 +136,60 @@ var Autolinker = {
 				if( anchorText.charAt( anchorText.length - 1 ) === '/' ) {
 					anchorText = anchorText.slice( 0, -1 );
 				}
-
+				
 				// Set the attributes for the anchor tag
 				anchorAttributes.push( 'href="' + anchorHref + '"' );
 				if( newWindow ) {
 					anchorAttributes.push( 'target="_blank"' );
 				}
-
+				
 				// Truncate the anchor text if it is longer than the provided 'truncate' option
 				if( truncate && anchorText.length > truncate ) {
 					anchorText = anchorText.substring( 0, truncate - 2 ) + '..';
 				}
-
+				
 				return prefixStr + '<a ' + anchorAttributes.join( " " ) + '>' + anchorText + '</a>' + suffixStr;  // wrap the match in an anchor tag
 			} );
-
+			
 			return text;
 		}
-
-
+		
+		
 		// Loop over the HTML string, ignoring HTML tags, and processing the text that lies between them,
-		// wrapping the URLs in anchor tags
+		// wrapping the URLs in anchor tags 
 		while( ( currentResult = htmlRegex.exec( html ) ) !== null ) {
 			var tagText = currentResult[ 0 ],
 			    tagName = currentResult[ 2 ],
 			    isClosingTag = !!currentResult[ 1 ];
-
+			
 			inBetweenTagsText = html.substring( lastIndex, currentResult.index );
 			lastIndex = currentResult.index + tagText.length;
-
+			
 			// Process around anchor tags, and any inner text / html they may have
 			if( tagName === 'a' ) {
 				if( !isClosingTag ) {  // it's the start <a> tag
 					anchorTagStackCount++;
 					resultHtml += autolinkText( inBetweenTagsText );
-
+					
 				} else {     // it's the end </a> tag
-					anchorTagStackCount--;
+					anchorTagStackCount--;	
 					if( anchorTagStackCount === 0 ) {
 						resultHtml += inBetweenTagsText;  // We hit the matching </a> tag, simply add all of the text from the start <a> tag to the end </a> tag without linking it
 					}
 				}
-
+				
 			} else if( anchorTagStackCount === 0 ) {   // not within an anchor tag, link the "in between" text
 				resultHtml += autolinkText( inBetweenTagsText );
 			}
-
+			
 			resultHtml += tagText;  // now add the text of the tag itself verbatim
 		}
-
+		
 		// Process any remaining text after the last HTML element. Will process all of the text if there were no HTML elements.
 		if( lastIndex < html.length ) {
 			resultHtml += autolinkText( html.substring( lastIndex ) );
 		}
-
+		
 		return resultHtml;
 	}
 

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -1,348 +1,348 @@
 /*global Autolinker, _, describe, beforeEach, afterEach, it, expect */
 describe( "Autolinker", function() {
-
+	
 	describe( "link()", function() {
-
+		
 		it( "should automatically link URLs in the form of http://www.yahoo.com", function() {
 			var result = Autolinker.link( "Joe went to http://www.yahoo.com" );
 			expect( result ).toBe( 'Joe went to <a href="http://www.yahoo.com" target="_blank">yahoo.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of http://yahoo.com", function() {
 			var result = Autolinker.link( "Joe went to http://yahoo.com" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com" target="_blank">yahoo.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of www.yahoo.com, prepending the http:// in this case", function() {
 			var result = Autolinker.link( "Joe went to www.yahoo.com" );
 			expect( result ).toBe( 'Joe went to <a href="http://www.yahoo.com" target="_blank">yahoo.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of subdomain.yahoo.com", function() {
 			var result = Autolinker.link( "Joe went to subdomain.yahoo.com" );
 			expect( result ).toBe( 'Joe went to <a href="http://subdomain.yahoo.com" target="_blank">subdomain.yahoo.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com, prepending the http:// in this case", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com" target="_blank">yahoo.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.co.uk, prepending the http:// in this case", function() {
 			var result = Autolinker.link( "Joe went to yahoo.co.uk" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.co.uk" target="_blank">yahoo.co.uk</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.ru, prepending the http:// in this case", function() {
 			var result = Autolinker.link( "Joe went to yahoo.ru" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.ru" target="_blank">yahoo.ru</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link 'yahoo.xyz', but not 'sencha.etc'", function() {
 			var result = Autolinker.link( "yahoo.xyz should be linked, sencha.etc should not", { newWindow: false } );
 			expect( result ).toBe( '<a href="http://yahoo.xyz">yahoo.xyz</a> should be linked, sencha.etc should not' );
 		} );
-
-
+		
+		
 		it( "should automatically link 'a.museum', but not 'abc.123'", function() {
 			var result = Autolinker.link( "a.museum should be linked, but abc.123 should not", { newWindow: false } );
 			expect( result ).toBe( '<a href="http://a.museum">a.museum</a> should be linked, but abc.123 should not' );
 		} );
-
-
+		
+		
 		describe( "parenthesis handling", function() {
-
+			
 			it( "should include parentheses in URLs", function() {
 				var result = Autolinker.link( "TLDs come from en.wikipedia.org/wiki/IANA_(disambiguation).", { newWindow: false } );
 				expect( result ).toBe( 'TLDs come from <a href="http://en.wikipedia.org/wiki/IANA_(disambiguation)">en.wikipedia.org/wiki/IANA_(disambiguation)</a>.' );
-
+				
 				var result = Autolinker.link( "MSDN has a great article at http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx.", { newWindow: false } );
 				expect( result ).toBe( 'MSDN has a great article at <a href="http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx">msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx</a>.' );
 			} );
-
-
+			
+			
 			it( "should include parentheses in URLs with query strings", function() {
 				var result = Autolinker.link( "TLDs come from en.wikipedia.org/wiki?IANA_(disambiguation).", { newWindow: false } );
 				expect( result ).toBe( 'TLDs come from <a href="http://en.wikipedia.org/wiki?IANA_(disambiguation)">en.wikipedia.org/wiki?IANA_(disambiguation)</a>.' );
-
+				
 				var result = Autolinker.link( "MSDN has a great article at http://msdn.microsoft.com/en-us/library?aa752574(VS.85).aspx.", { newWindow: false } );
 				expect( result ).toBe( 'MSDN has a great article at <a href="http://msdn.microsoft.com/en-us/library?aa752574(VS.85).aspx">msdn.microsoft.com/en-us/library?aa752574(VS.85).aspx</a>.' );
 			} );
-
-
+			
+			
 			it( "should include parentheses in URLs with hash anchors", function() {
 				var result = Autolinker.link( "TLDs come from en.wikipedia.org/wiki#IANA_(disambiguation).", { newWindow: false } );
 				expect( result ).toBe( 'TLDs come from <a href="http://en.wikipedia.org/wiki#IANA_(disambiguation)">en.wikipedia.org/wiki#IANA_(disambiguation)</a>.' );
-
+				
 				var result = Autolinker.link( "MSDN has a great article at http://msdn.microsoft.com/en-us/library#aa752574(VS.85).aspx.", { newWindow: false } );
 				expect( result ).toBe( 'MSDN has a great article at <a href="http://msdn.microsoft.com/en-us/library#aa752574(VS.85).aspx">msdn.microsoft.com/en-us/library#aa752574(VS.85).aspx</a>.' );
 			} );
-
-
+			
+			
 			it( "should include parentheses in URLs, when the URL is also in parenthesis itself", function() {
 				var result = Autolinker.link( "TLDs come from (en.wikipedia.org/wiki/IANA_(disambiguation)).", { newWindow: false } );
 				expect( result ).toBe( 'TLDs come from (<a href="http://en.wikipedia.org/wiki/IANA_(disambiguation)">en.wikipedia.org/wiki/IANA_(disambiguation)</a>).' );
-
+				
 				var result = Autolinker.link( "MSDN has a great article at (http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx).", { newWindow: false } );
 				expect( result ).toBe( 'MSDN has a great article at (<a href="http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx">msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx</a>).' );
 			} );
-
-
+			
+			
 			it( "should not include a final closing paren in the URL, if it doesn't match an opening paren in the url", function() {
 				var result = Autolinker.link( "Click here (google.com) for more details" );
 				expect( result ).toBe( 'Click here (<a href="http://google.com" target="_blank">google.com</a>) for more details' );
 			} );
-
-
+			
+			
 			it( "should not include a final closing paren in the URL when a path exists", function() {
 				var result = Autolinker.link( "Click here (google.com/abc) for more details" );
 				expect( result ).toBe( 'Click here (<a href="http://google.com/abc" target="_blank">google.com/abc</a>) for more details' );
 			} );
-
-
+			
+			
 			it( "should not include a final closing paren in the URL when a query string exists", function() {
 				var result = Autolinker.link( "Click here (google.com?abc=1) for more details" );
 				expect( result ).toBe( 'Click here (<a href="http://google.com?abc=1" target="_blank">google.com?abc=1</a>) for more details' );
 			} );
-
-
+			
+			
 			it( "should not include a final closing paren in the URL when a hash anchor exists", function() {
 				var result = Autolinker.link( "Click here (google.com#abc) for more details" );
 				expect( result ).toBe( 'Click here (<a href="http://google.com#abc" target="_blank">google.com#abc</a>) for more details' );
 			} );
-
-
+			
+			
 			it( "should include escaped parentheses in the URL", function() {
 				var result = Autolinker.link( "Here's an example from CodingHorror: http://en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29" );
 				expect( result ).toBe( 'Here\'s an example from CodingHorror: <a href="http://en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29" target="_blank">en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29</a>' );
 			} );
-
+			
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com/path/to/file.html, handling the path", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com/path/to/file.html" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/path/to/file.html" target="_blank">yahoo.com/path/to/file.html</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com?hi=1, handling the query string", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com?hi=1" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com?hi=1" target="_blank">yahoo.com?hi=1</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com#index1, handling the hash", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com#index1" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com#index1" target="_blank">yahoo.com#index1</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com/path/to/file.html?hi=1, handling the path and the query string", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com/path/to/file.html?hi=1" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/path/to/file.html?hi=1" target="_blank">yahoo.com/path/to/file.html?hi=1</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com/path/to/file.html#index1, handling the path and the hash", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com/path/to/file.html#index1" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/path/to/file.html#index1" target="_blank">yahoo.com/path/to/file.html#index1</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of yahoo.com/path/to/file.html?hi=1#index1, handling the path, query string, and hash", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com/path/to/file.html?hi=1#index1" );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/path/to/file.html?hi=1#index1" target="_blank">yahoo.com/path/to/file.html?hi=1#index1</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link a URL with a complex hash (such as a Google Analytics url)", function() {
 			var result = Autolinker.link( "Joe went to https://www.google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25/ and analyzed his analytics" );
 			expect( result ).toBe( 'Joe went to <a href="https://www.google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25/" target="_blank">google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25</a> and analyzed his analytics' );
 		} );
-
-
+		
+		
 		it( "should automatically link multiple URLs", function() {
 			var result = Autolinker.link( 'Joe went to http://yahoo.com and http://google.com' );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com" target="_blank">yahoo.com</a> and <a href="http://google.com" target="_blank">google.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of 'http://yahoo.com.', without including the trailing period", function() {
 			var result = Autolinker.link( "Joe went to http://yahoo.com." );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com" target="_blank">yahoo.com</a>.' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of 'www.yahoo.com.', without including the trailing period", function() {
 			var result = Autolinker.link( "Joe went to www.yahoo.com." );
 			expect( result ).toBe( 'Joe went to <a href="http://www.yahoo.com" target="_blank">yahoo.com</a>.' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of 'yahoo.com.', without including the trailing period", function() {
 			var result = Autolinker.link( "Joe went to yahoo.com." );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com" target="_blank">yahoo.com</a>.' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs in the form of 'http://yahoo.com/sports.', without including the trailing period", function() {
 			var result = Autolinker.link( "Joe went to http://yahoo.com/sports." );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/sports" target="_blank">yahoo.com/sports</a>.' );
 		} );
-
-
+		
+		
 		it( "should remove trailing slash from 'http://yahoo.com/'", function() {
 			var result = Autolinker.link( "Joe went to http://yahoo.com/." );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/" target="_blank">yahoo.com</a>.' );
 		} );
-
-
+		
+		
 		it( "should remove trailing slash from 'http://yahoo.com/sports/'", function() {
 			var result = Autolinker.link( "Joe went to http://yahoo.com/sports/." );
 			expect( result ).toBe( 'Joe went to <a href="http://yahoo.com/sports/" target="_blank">yahoo.com/sports</a>.' );
 		} );
-
-
+		
+		
 		it( "should automatically link an email address which is the only text in the string", function() {
 			var result = Autolinker.link( "joe@joe.com" );
 			expect( result ).toBe( '<a href="mailto:joe@joe.com" target="_blank">joe@joe.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link email addresses at the start of the string", function() {
 			var result = Autolinker.link( "joe@joe.com is Joe's email" );
 			expect( result ).toBe( '<a href="mailto:joe@joe.com" target="_blank">joe@joe.com</a> is Joe\'s email' );
 		} );
-
-
+		
+		
 		it( "should automatically link an email address in the middle of the string", function() {
 			var result = Autolinker.link( "Joe's email is joe@joe.com because it is" );
 			expect( result ).toBe( 'Joe\'s email is <a href="mailto:joe@joe.com" target="_blank">joe@joe.com</a> because it is' );
 		} );
-
-
+		
+		
 		it( "should automatically link email addresses at the end of the string", function() {
 			var result = Autolinker.link( "Joe's email is joe@joe.com" );
 			expect( result ).toBe( 'Joe\'s email is <a href="mailto:joe@joe.com" target="_blank">joe@joe.com</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link email addresses with a period in the 'local part'", function() {
 			var result = Autolinker.link( "Joe's email is joe.smith@joe.com" );
 			expect( result ).toBe( 'Joe\'s email is <a href="mailto:joe.smith@joe.com" target="_blank">joe.smith@joe.com</a>' );
 		} );
-
-
+		
+		
 		it( "should NOT automatically link any old word with an @ character in it", function() {
 			var result = Autolinker.link( "Hi there@stuff" );
 			expect( result ).toBe( 'Hi there@stuff' );
 		} );
-
-
+		
+		
 		it( "should automatically link a twitter handle which is the only thing in the string", function() {
 			var result = Autolinker.link( "@joe_the_man12" );
 			expect( result ).toBe( '<a href="https://twitter.com/joe_the_man12" target="_blank">@joe_the_man12</a>' );
 		} );
-
-
+		
+		
 		it( "should automatically link twitter handles at the beginning of a string", function() {
 			var result = Autolinker.link( "@greg is my twitter handle" );
 			expect( result ).toBe( '<a href="https://twitter.com/greg" target="_blank">@greg</a> is my twitter handle' );
 		} );
-
-
+		
+		
 		it( "should automatically link twitter handles in the middle of a string", function() {
 			var result = Autolinker.link( "Joe's twitter is @joe_the_man12 today, but what will it be tomorrow?" );
 			expect( result ).toBe( 'Joe\'s twitter is <a href="https://twitter.com/joe_the_man12" target="_blank">@joe_the_man12</a> today, but what will it be tomorrow?' );
 		} );
-
-
+		
+		
 		it( "should automatically link twitter handles at the end of a string", function() {
 			var result = Autolinker.link( "Joe's twitter is @joe_the_man12" );
 			expect( result ).toBe( 'Joe\'s twitter is <a href="https://twitter.com/joe_the_man12" target="_blank">@joe_the_man12</a>' );
 		} );
-
-
-        it( "should automatically link multiple twitter handles in a string", function() {
-            var result = Autolinker.link( "@greg is tweeting @joe with @josh" );
-            expect( result ).toBe( '<a href="https://twitter.com/greg" target="_blank">@greg</a> is tweeting <a href="https://twitter.com/joe" target="_blank">@joe</a> with <a href="https://twitter.com/josh" target="_blank">@josh</a>' );
-        } );
-
-
+		
+		
+		it( "should automatically link multiple twitter handles in a string", function() {
+			var result = Autolinker.link( "@greg is tweeting @joe with @josh" );
+			expect( result ).toBe( '<a href="https://twitter.com/greg" target="_blank">@greg</a> is tweeting <a href="https://twitter.com/joe" target="_blank">@joe</a> with <a href="https://twitter.com/josh" target="_blank">@josh</a>' );
+		} );
+		
+		
 		it( "should NOT automatically link URLs within HTML tags", function() {
 			var result = Autolinker.link( '<p>Joe went to <a href="http://www.yahoo.com">yahoo</a></p>' );
 			expect( result ).toBe( '<p>Joe went to <a href="http://www.yahoo.com">yahoo</a></p>' );
 		} );
-
-
+		
+		
 		it( "should automatically link URLs past the last HTML tag", function() {
 			var result = Autolinker.link( '<p>Joe went to <a href="http://www.yahoo.com">yahoo</a></p> and http://google.com' );
 			expect( result ).toBe( '<p>Joe went to <a href="http://www.yahoo.com">yahoo</a></p> and <a href="http://google.com" target="_blank">google.com</a>' );
 		} );
-
-
+		
+		
 		it( "should NOT automatically link a URL found within the inner text of a pre-existing anchor tag", function() {
 			var result = Autolinker.link( '<p>Joe went to <a href="http://www.yahoo.com">yahoo.com</a></p> yesterday.' );
 			expect( result ).toBe( '<p>Joe went to <a href="http://www.yahoo.com">yahoo.com</a></p> yesterday.' );
 		} );
-
-
+		
+		
 		it( "should NOT automatically link a URL found within the inner text of a pre-existing anchor tag, but link others", function() {
 			var result = Autolinker.link( '<p>Joe went to google.com, <a href="http://www.yahoo.com">yahoo.com</a>, and weather.com</p> yesterday.' );
 			expect( result ).toBe( '<p>Joe went to <a href="http://google.com" target="_blank">google.com</a>, <a href="http://www.yahoo.com">yahoo.com</a>, and <a href="http://weather.com" target="_blank">weather.com</a></p> yesterday.' );
 		} );
-
-
+		
+		
 		it( "should NOT automatically link an image tag with a URL inside it, inside an anchor tag", function() {
 			var result = Autolinker.link( '<a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a>' );
 			expect( result ).toBe( '<a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a>' );
 		} );
-
-
+		
+		
 		it( "should NOT automatically link an image tag with a URL inside it, inside an anchor tag, but match urls around the tags", function() {
 			var result = Autolinker.link( 'google.com looks like <a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a> (at google.com)' );
 			expect( result ).toBe( '<a href="http://google.com" target="_blank">google.com</a> looks like <a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a> (at <a href="http://google.com" target="_blank">google.com</a>)' );
 		} );
-
-
+		
+		
 		it( "should not add target=\"_blank\" when the 'newWindow' option is set to false", function() {
 			var result = Autolinker.link( "Test http://url.com", { newWindow: false } );
 			expect( result ).toBe( 'Test <a href="http://url.com">url.com</a>' );
 		} );
-
-
+		
+		
 		it( "should not remove the prefix for non-http protocols", function() {
 			var result = Autolinker.link( "Test file://execute-virus.com" );
 			expect( result ).toBe( 'Test <a href="file://execute-virus.com" target="_blank">file://execute-virus.com</a>' );
 		} );
-
-
+		
+		
 		it( "should not remove 'http://www.' when the 'stripPrefix' option is set to false", function() {
 			var result = Autolinker.link( "Test http://www.url.com", { stripPrefix: false } );
 			expect( result ).toBe( 'Test <a href="http://www.url.com" target="_blank">http://www.url.com</a>' );
 		} );
-
-
+		
+		
 		it( "should truncate long a url/email/twitter to the given number of characters with the 'truncate' option specified", function() {
 			var result = Autolinker.link( "Test http://url.com/with/path", { truncate: 12 } );
 			expect( result ).toBe( 'Test <a href="http://url.com/with/path" target="_blank">url.com/wi..</a>' );
 		} );
-
-
+		
+		
 		it( "should leave a url/email/twitter alone if the length of the url is exactly equal to the length of the 'truncate' option", function() {
 			var result = Autolinker.link( "Test http://url.com/with/path", { truncate: 'url.com/with/path'.length } );  // the exact length of the link
 			expect( result ).toBe( 'Test <a href="http://url.com/with/path" target="_blank">url.com/with/path</a>' );
 		} );
-
-
+		
+		
 		it( "should leave a url/email/twitter alone if it does not exceed the given number of characters provided in the 'truncate' option", function() {
 			var result = Autolinker.link( "Test http://url.com/with/path", { truncate: 25 } );  // just a random high number
 			expect( result ).toBe( 'Test <a href="http://url.com/with/path" target="_blank">url.com/with/path</a>' );
@@ -407,7 +407,7 @@ describe( "Autolinker", function() {
                 expect( result ).toBe( 'Joe\'s email is <a href="mailto:joe@joe.com" target="_blank">joe@joe.com</a> because it is' );
             } );
         });
-
+		
 	} );
-
+	
 } );


### PR DESCRIPTION
My usage didn't want Twitter handles to be auto-linked, and sometimes only wanted email addresses to be linked, so I've added some extra options to control which of the three types should be processed.

This still uses the same regex to match all 3 link types regardless of which are enabled - it merely skips over link types that aren't wanted when processing them into `<a>` tags. This is perhaps not ideal for performance (especially if the `.link()` function is being called repeatedly), but it saves us having multiple regular expressions (which in turn saves the client having to download and compile multiple regex patterns). I'm satisfied with the trade-off, there.

This could arguably do with more tests, too. The included tests show that it essentially works, but there are many avenues where it could _potentially_ fail, in theory, so more tests are always beneficial, I guess! I've been a little too pushed for time to write any more tests than absolutely necessary... (Testing/QA is always the first to be cut in a budget/deadline squeeze, eh? :))

**Note:** this pull request doesn't include any of the files in `/dist/` as I figured that they would only be a monumental pain in the arse to merge, but it means that anyone downloading an archive of this project immediately after this PR is merged wouldn't have this functionality available in the compiled files in `/dist/`, so the code will need to be built and committed before it's done. I'm happy to include the `/dist/` files in the PR if you wish - just let me know! :)
