### PR TITLE
add 'classname' option

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -70,6 +70,7 @@
 			var htmlRegex = Autolinker.htmlRegex,         // full path for friendly
 				matcherRegex = Autolinker.matcherRegex,   // out-of-scope calls
 				newWindow = ( 'newWindow' in options ) ? options.newWindow : true,  // defaults to true
+				classname = typeof options.classname === 'string' && options.classname.length > 0 ? options.classname : false, // defaults to false
 				stripPrefix = ( 'stripPrefix' in options ) ? options.stripPrefix : true,  // defaults to true
 				truncate = options.truncate,
 				enableTwitter = ( 'twitter' in options ) ? options.twitter : true,  // defaults to true
@@ -128,11 +129,9 @@
 						prefixStr = twitterHandlePrefixWhitespaceChar;
 						anchorHref = 'https://twitter.com/' + twitterHandle;
 						anchorText = '@' + twitterHandle;
-					
 					} else if( emailAddress ) {
 						anchorHref = 'mailto:' + emailAddress;
 						anchorText = emailAddress;
-					
 					} else if( !/^[A-Za-z]{3,9}:/i.test( anchorHref ) ) {  // string doesn't begin with a protocol, add http://
 						anchorHref = 'http://' + anchorHref;
 					}
@@ -146,8 +145,16 @@
 						anchorText = anchorText.slice( 0, -1 );
 					}
 					
+
 					// Set the attributes for the anchor tag
+					if ( classname ){
+						twitterMatch && anchorAttributes.push( 'class="' + classname + '-twitter' + '"' );
+						emailAddress && anchorAttributes.push( 'class="' + classname + '-email' + '"' );
+						!twitterMatch && !emailAddress && anchorAttributes.push( 'class="' + classname + '-url' + '"' );
+					}
+
 					anchorAttributes.push( 'href="' + anchorHref + '"' );
+
 					if( newWindow ) {
 						anchorAttributes.push( 'target="_blank"' );
 					}
@@ -156,7 +163,7 @@
 					if( truncate && anchorText.length > truncate ) {
 						anchorText = anchorText.substring( 0, truncate - 2 ) + '..';
 					}
-					
+
 					return prefixStr + '<a ' + anchorAttributes.join( " " ) + '>' + anchorText + '</a>' + suffixStr;  // wrap the match in an anchor tag
 				} );
 				

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -433,6 +433,42 @@ describe( "Autolinker", function() {
 			
 		} );
 		
+		describe( "`classname` option", function() {
+		
+			it( "should not add classname when the 'classname' option is not a string with at least 1 character", function() {
+				var result = Autolinker.link( "Test http://url.com" );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+
+				result = Autolinker.link( "Test http://url.com", { classname: '' } );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+
+				result = Autolinker.link( "Test http://url.com", { classname: null } );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+
+				result = Autolinker.link( "Test http://url.com", { classname: {} } );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+
+				result = Autolinker.link( "Test http://url.com", { classname: true } );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+
+				result = Autolinker.link( "Test http://url.com", { classname: 12 } );
+				expect( result ).toBe( 'Test <a href="http://url.com" target="_blank">url.com</a>' );
+			} );
+
+			it( "should add classname to links", function() {
+				var result = Autolinker.link( "Test http://url.com", { classname: 'is' } );
+				expect( result ).toBe( 'Test <a class="is-url" href="http://url.com" target="_blank">url.com</a>' );
+			} );
+
+			it( "should add classname to twitter links", function() {
+				var result = Autolinker.link( "hi from @iggypopschest", { twitter: true, classname: 'is' } );
+				expect( result ).toBe( 'hi from <a class="is-twitter" href="https://twitter.com/iggypopschest" target="_blank">@iggypopschest</a>' );
+			} );
+
+			it( "should add classname to email links", function() {
+				var result = Autolinker.link( "Iggy's email is mr@iggypop.com", { email: true, classname: 'is' } );
+				expect( result ).toBe( 'Iggy\'s email is <a class="is-email" href="mailto:mr@iggypop.com" target="_blank">mr@iggypop.com</a>' );
+			} );
+		} );
 	} );
-	
 } );


### PR DESCRIPTION
here's another one I needed to support my project. my use-case is pretty straight-forward: i want to style detected links differently than others.

the new `classname` option:
- accepts a string w/ length > 0
- uses value as prefix for css classname
- applies classname suffix based on link type (email, twitter, etc)

the thing I don't love as it stands is: the option name doesn't do a great job of explaining what will happen (i imagine most will assume it simply adds the given classname(s) to the anchor tag where it really treats the provided string as a prefix - where `prefix-<link type>` is the result) :stuck_out_tongue_winking_eye:

also, i owe docs for it... happy to tackle that if it seems like a worthy addition. let me know what ya think!
