### PR TITLE
Improve `htmlRegex` to allow hyphens (etc.) in attribute names

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -205,7 +205,7 @@
 		 * 1. If it is an end tag, this group will have the '/'.
 		 * 2. The tag name.
 		 */
-		htmlRegex : /<(\/)?(\w+)(?:(?:\s+\w+(?:\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)\/?>/g,
+        htmlRegex : /<(\/)?([0-9a-zA-Z:]+)(?:(?:\s+[^\s\0"'>\/=\x01-\x1F\x7F]+(?:\s*=\s*(?:".*?"|'.*?'|[^'"=<>`\s]+))?)+\s*|\s*)\/?>/g,
 
 		/**
 		 * @private

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -207,6 +207,13 @@ describe( "Autolinker", function() {
 		} );
 		
 		
+        it( "should allow the full range of HTML attribute name characters as specified in the W3C HTML syntax document (http://www.w3.org/TR/html-markup/syntax.html)", function() {
+            // We aren't actually expecting the HTML to be modified by this test
+            var inAndOutHtml = "<ns:p>Foo <a data-qux-=\"\" href=\"http:\/\/www.example.com\" target=\"_blank\">Bar<\/a> Baz<\/ns:p>";
+            expect( Autolinker.link( inAndOutHtml ) ).toBe( inAndOutHtml );
+        } );
+
+
 		describe( "parenthesis handling", function() {
 			
 			it( "should include parentheses in URLs", function() {


### PR DESCRIPTION
Updated the `htmlRegex` so that its allowed ranges of characters for HTML tag
names and attribute names more closely reflect those specified by the W3C HTML
Syntax document (http://www.w3.org/TR/html-markup/syntax.html).

Specifically, this allows attribute names containing hyphens (such as
`data-blah="foo"` attributes, as made popular by jQuery) and should also permit
tags with XML namespaces. Previously if tags containing "invalid" attribute
names were passed into the `link()` function, the HTML string would be
completely bastardised, entirely stripping out most tag values (I ended up with
a sizeable document containing lots of markup but no actual content!).
