### PR TITLE
fix in bower.json 'main' section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Autolinker.js",
-  "main": "Autolinker.js",
+  "main": "dist/Autolinker.js",
   "homepage": "https://github.com/gregjacobs/Autolinker.js",
   "authors": [
     "Gregory Jacobs <greg@greg-jacobs.com>"


### PR DESCRIPTION
Hi,

Using grunt (and grunt-bower-install), when I do some action (build, deploy, serve) that involve the autoinjection of bower components grunt-bower-install injects Autolinker.js wrong:

```
<!-- bower:js -->
...
<script src="bower_components/Autolinker.js/Autolinker.js"></script>
...
<!-- endbower -->
```

The `dist` subdirectory was missing.
