### PR TITLE
Update Autolinker.js

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -508,7 +508,7 @@
 		 * @return {String} The processed `anchorText`.
 		 */
 		processAnchorText : function( anchorText ) {
-			if( this.stripPrefix ) {
+			if( !this.stripPrefix ) {
 				anchorText = this.stripUrlPrefix( anchorText );
 			}
 			anchorText = this.removeTrailingSlash( anchorText );  // remove trailing slash, if there is one


### PR DESCRIPTION
Fix for stripping the URL prefix not working for default scenario. Always remove the URL prefix when you call the Autolinker.link();
