### PR TITLE
Option to include Amazon affiliates Tracking ID

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -117,7 +117,7 @@
 		className : "",
 		
 		/**
-		 * @cfg {String} amazonAffiliateId
+		 * @cfg {String} amazonTrackingId
 		 * 
 		 * Your Amazon Affiliate Program tracking ID, to be added to any generated Amazon links.
 		 * 
@@ -125,7 +125,7 @@
 		 * 
 		 * 1) Amazon URL links will have the following appended to them: "tag=memosync-20"
 		 */
-		amazonAffiliateId : "",		
+		amazonTrackingId : "",		
 		
 		
 		/**
@@ -461,6 +461,13 @@
 		 * @return {String} The full HTML for the anchor tag.
 		 */
 		createAnchorTag : function( linkType, anchorHref, anchorText ) {
+			
+			//include amazon tracking id if specified
+		       if (anchorHref.match(/amazon\./i) && this.amazonTrackingId) {
+		         anchorHref = anchorHref.replace('tag=','oldtag=');
+		         anchorHref = anchorHref + ((anchorHref.indexOf('?') == -1) ? '?tag=' : '&tag=') + this.amazonTrackingId;
+		       }			
+			
 			var attributesStr = this.createAnchorAttrsStr( linkType, anchorHref );
 			anchorText = this.processAnchorText( anchorText );
 			


### PR DESCRIPTION
I have added the option to specify an Amazon affiliates tracking ID and have it automatically appended to any Amazon links. Thanks!
