### PR TITLE
Fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ JavaScript:
 ```javascript
 var Autolinker = require( 'autolinker' );
 // note: npm wants an all-lowercase package name, but the utility is a class and should be 
-// aliased with a captial letter
+// aliased with a capital letter
 ```
 
 


### PR DESCRIPTION
`captial` to `capital` 
