### PR TITLE
TwitterHashtag Support Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ So, this utility attempts to handle everything. It:
 - Will properly handle URLs with query parameters or a named anchor (i.e. hash)
 - Will autolink email addresses.
 - Will autolink Twitter handles.
+- Will autolink TwitterHashtag handles.
 - Will properly handle HTML input. The utility will not change the `href` attribute inside anchor (&lt;a&gt;) tags (or any other 
   tag/attribute for that matter), and will not accidentally wrap the inner text of an anchor tag with a new one (which would cause 
   doubly-nested anchor tags).
@@ -90,17 +91,18 @@ These are the options which may be specified for linking. These are specified by
 - [stripPrefix](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-stripPrefix) : Boolean<br />
   `true` to have the 'http://' or 'https://' and/or the 'www.' stripped from the beginning of links, `false` otherwise. Defaults to `true`.<br /><br />
 - [truncate](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-truncate) : Number<br />
-  A number for how many characters long URLs/emails/twitter handles should be truncated to inside the text of a link. If the URL/email/twitter is over the number of characters, it will be truncated to this length by replacing the end of the string with a two period ellipsis ('..').<br /><br />
+  A number for how many characters long URLs/emails/twitter handles/twitterHashtag handles should be truncated to inside the text of a link. If the URL/email/twitter/twitterHashtag is over the number of characters, it will be truncated to this length by replacing the end of the string with a two period ellipsis ('..').<br /><br />
   Example: a url like 'http://www.yahoo.com/some/long/path/to/a/file' truncated to 25 characters may look like this: 'yahoo.com/some/long/pat..'<br /><br />
 - [className](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-className) : String<br />
   A CSS class name to add to the generated anchor tags. This class will be added to all links, as well as this class
-  plus "url"/"email"/"twitter" suffixes for styling url/email/twitter links differently.
+  plus "url"/"email"/"twitter"/"twitterHashtag" suffixes for styling url/email/twitter/twitterHashtag links differently.
   
   For example, if this config is provided as "myLink", then:
   
   1) URL links will have the CSS classes: "myLink myLink-url"<br />
   2) Email links will have the CSS classes: "myLink myLink-email", and<br />
   3) Twitter links will have the CSS classes: "myLink myLink-twitter"<br />
+  4) TwitterHashtag links will have the CSS classes: "myLink myLink-twitterHashtag"<br />
   
 - [urls](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-urls) : Boolean<br />
   `true` to have URLs auto-linked, `false` to skip auto-linking of URLs. Defaults to `true`.<br />
@@ -108,6 +110,8 @@ These are the options which may be specified for linking. These are specified by
   `true` to have email addresses auto-linked, `false` to skip auto-linking of email addresses. Defaults to `true`.<br /><br />
 - [twitter](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-twitter) : Boolean<br />
   `true` to have Twitter handles auto-linked, `false` to skip auto-linking of Twitter handles. Defaults to `true`.<br /><br />
+- [twitterHashtag](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-twitterHashtag) : Boolean<br />
+  `true` to have TwitterHashtag handles auto-linked, `false` to skip auto-linking of TwitterHashtag handles. Defaults to `true`.<br /><br />
 - [replaceFn](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-replaceFn) : Function<br />
   A function to use to programmatically make replacements of matches in the input string, one at a time. See the section 
   <a href="#custom-replacement-function">Custom Replacement Function</a> for more details.
@@ -155,13 +159,13 @@ autolinker.link( "Go to www.google.com" );
 
 ## Custom Replacement Function
 
-A custom replacement function ([replaceFn](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-replaceFn)) may be provided to replace url/email/twitter matches on an individual basis, based
+A custom replacement function ([replaceFn](http://gregjacobs.github.io/Autolinker.js/docs/#!/api/Autolinker-cfg-replaceFn)) may be provided to replace url/email/twitter/twitterHashtag matches on an individual basis, based
 on the return from this function.
 
 Full example, for purposes of documenting the API:
 
 ```javascript
-var input = "...";  // string with URLs, Email Addresses, and Twitter Handles
+var input = "...";  // string with URLs, Email Addresses, Twitter Handles, and TwitterHashtag Handles
 
 var linkedText = Autolinker.link( input, {
     replaceFn : function( autolinker, match ) {
@@ -198,6 +202,11 @@ var linkedText = Autolinker.link( input, {
                 console.log( twitterHandle );
         
                 return '<a href="http://newplace.to.link.twitter.handles.to/">' + twitterHandle + '</a>';
+            case 'twitterHashtag' :
+                var twitterHashtagHandle = match.getTwitterHashtagHandle();
+                console.log( twitterHashtagHandle );
+        
+                return '<a href="http://newplace.to.link.twitterHashtag.handles.to/">' + twitterHashtagHandle + '</a>';
         }
     }
 } );

--- a/src/AnchorTagBuilder.js
+++ b/src/AnchorTagBuilder.js
@@ -51,7 +51,7 @@ Autolinker.AnchorTagBuilder = Autolinker.Util.extend( Object, {
 	
 	
 	/**
-	 * Generates the actual anchor (&lt;a&gt;) tag to use in place of the matched URL/email/Twitter text,
+	 * Generates the actual anchor (&lt;a&gt;) tag to use in place of the matched URL/email/Twitter/TwitterHashtag text,
 	 * via its `match` object.
 	 * 
 	 * @param {Autolinker.match.Match} match The Match instance to generate an anchor tag from.
@@ -72,7 +72,7 @@ Autolinker.AnchorTagBuilder = Autolinker.Util.extend( Object, {
 	 * Creates the Object (map) of the HTML attributes for the anchor (&lt;a&gt;) tag being generated.
 	 * 
 	 * @protected
-	 * @param {"url"/"email"/"twitter"} matchType The type of match that an anchor tag is being generated for.
+	 * @param {"url"/"email"/"twitter"/"twitterHashtag"} matchType The type of match that an anchor tag is being generated for.
 	 * @param {String} href The href for the anchor tag.
 	 * @return {Object} A key/value Object (map) of the anchor tag's attributes. 
 	 */
@@ -98,7 +98,7 @@ Autolinker.AnchorTagBuilder = Autolinker.Util.extend( Object, {
 	 * config.
 	 * 
 	 * @private
-	 * @param {"url"/"email"/"twitter"} matchType The type of match that an anchor tag is being generated for.
+	 * @param {"url"/"email"/"twitter"/"twitterHashtag"} matchType The type of match that an anchor tag is being generated for.
 	 * @return {String} The CSS class string for the link. Example return: "myLink myLink-url". If no {@link #className}
 	 *   was configured, returns an empty string.
 	 */
@@ -108,7 +108,7 @@ Autolinker.AnchorTagBuilder = Autolinker.Util.extend( Object, {
 		if( !className ) 
 			return "";
 		else
-			return className + " " + className + "-" + matchType;  // ex: "myLink myLink-url", "myLink myLink-email", or "myLink myLink-twitter"
+			return className + " " + className + "-" + matchType;  // ex: "myLink myLink-url", "myLink myLink-email", "myLink myLink-twitter", or "myLink myLink-twitterHashtag"
 	},
 	
 	

--- a/src/match/TwitterHashtag.js
+++ b/src/match/TwitterHashtag.js
@@ -1,0 +1,58 @@
+/*global Autolinker */
+/**
+ * @class Autolinker.match.TwitterHashtag
+ * @extends Autolinker.match.Match
+ * 
+ * Represents a TwitterHashtag match found in an input string which should be Autolinked.
+ * 
+ * See this class's superclass ({@link Autolinker.match.Match}) for more details.
+ */
+Autolinker.match.TwitterHashtag = Autolinker.Util.extend( Autolinker.match.Match, {
+	
+	/**
+	 * @cfg {String} twitterHashtagHandle (required)
+	 * 
+	 * The TwitterHashtag handle that was matched.
+	 */
+	
+
+	/**
+	 * Returns the type of match that this class represents.
+	 * 
+	 * @return {String}
+	 */
+	getType : function() {
+		return 'twitterHashtag';
+	},
+	
+	
+	/**
+	 * Returns a string name for the type of match that this class represents.
+	 * 
+	 * @return {String}
+	 */
+	getTwitterHashtagHandle : function() {
+		return this.twitterHashtagHandle;
+	},
+	
+
+	/**
+	 * Returns the anchor href that should be generated for the match.
+	 * 
+	 * @return {String}
+	 */
+	getAnchorHref : function() {
+		return 'https://twitter.com/hashtag/' + this.twitterHashtagHandle;
+	},
+	
+	
+	/**
+	 * Returns the anchor text that should be generated for the match.
+	 * 
+	 * @return {String}
+	 */
+	getAnchorText : function() {
+		return '#' + this.twitterHashtagHandle;
+	}
+	
+} );


### PR DESCRIPTION
Added Support for twitter hashtags.
Now Autolinker will create a link for #someHashtag like it did for @someTwitterUser