### PR TITLE
Security: Use case-insensitive matching for forbidden protocols

### DIFF
--- a/src/matchParser/MatchValidator.js
+++ b/src/matchParser/MatchValidator.js
@@ -101,7 +101,7 @@ Autolinker.MatchValidator = Autolinker.Util.extend( Object, {
 	 * @return {Boolean} `true` if the scheme is a valid one, `false` otherwise.
 	 */
 	isValidUriScheme : function( uriSchemeMatch ) {
-		var uriScheme = uriSchemeMatch.match( this.uriSchemeRegex )[ 0 ];
+		var uriScheme = uriSchemeMatch.match( this.uriSchemeRegex )[ 0 ].toLowerCase();
 		
 		return ( uriScheme !== 'javascript:' && uriScheme !== 'vbscript:' );
 	},


### PR DESCRIPTION
Protocols are case-insensitive in browsers, so our check needs to be as well. Not posting a weaponized payload, but I've confirmed it's exploitable.