### PR TITLE
Use spaces instead of whitespace at phoneRegex

### DIFF
--- a/src/matchParser/MatchParser.js
+++ b/src/matchParser/MatchParser.js
@@ -105,7 +105,7 @@ Autolinker.matchParser.MatchParser = Autolinker.Util.extend( Object, {
 		    hashtagRegex = /(^|[^\w])#(\w{1,139})/,              // For matching a Hashtag. Ex: #games
 
 		    emailRegex = /(?:[\-;:&=\+\$,\w\.]+@)/,             // something@ for email addresses (a.k.a. local-part)
-		    phoneRegex = /(?:\+?\d{1,3}[-\s.])?\(?\d{3}\)?[-\s.]?\d{3}[-\s.]\d{4}/,  // ex: (123) 456-7890, 123 456 7890, 123-456-7890, etc.
+		    phoneRegex = /(?:\+?\d{1,3}[-\040.])?\(?\d{3}\)?[-\040.]?\d{3}[-\040.]\d{4}/,  // ex: (123) 456-7890, 123 456 7890, 123-456-7890, etc.
 		    protocolRegex = /(?:[A-Za-z][-.+A-Za-z0-9]*:(?![A-Za-z][-.+A-Za-z0-9]*:\/\/)(?!\d+\/?)(?:\/\/)?)/,  // match protocol, allow in format "http://" or "mailto:". However, do not match the first part of something like 'link:http://www.google.com' (i.e. don't match "link:"). Also, make sure we don't interpret 'google.com:8000' as if 'google.com' was a protocol here (i.e. ignore a trailing port number in this regex)
 		    wwwRegex = /(?:www\.)/,                             // starting with 'www.'
 		    domainNameRegex = /[A-Za-z0-9\.\-]*[A-Za-z0-9\-]/,  // anything looking at all like a domain, non-unicode domains, not ending in a period

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -901,6 +901,13 @@ describe( "Autolinker", function() {
 				expect( autolinker.link( "15417543010" ) ).toBe( '15417543010' );
 			} );
 
+
+			it( "should NOT automatically link numbers when there are non-space empty characters (such as newlines) in between", function() {
+				expect( autolinker.link( "555 666  7777" ) ).toBe( '555 666  7777' );
+				expect( autolinker.link( "555	666 7777" ) ).toBe( '555	666 7777' );
+				expect( autolinker.link( "555\n666 7777" ) ).toBe( '555\n666 7777' );
+			} );
+
 		} );
 
 


### PR DESCRIPTION
Solves issues with multiple spaces, tabs, new lines etc.

`\040` matches space character only; `\s` matches everything, tabs and all that stuff.

Old: http://rubular.com/r/9hbxQPKhsp
New: http://rubular.com/r/oM9xZ8jw1m

Includes a new test for this.

Regarding https://github.com/gregjacobs/Autolinker.js/issues/95#issuecomment-153414896