### PR TITLE
Whitelist npm packaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.22.0",
   "description": "Utility to automatically link the URLs, email addresses, and Twitter handles in a given block of text/HTML",
   "main": "dist/Autolinker.js",
+  "files": [
+  	"dist"
+  ],
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
This will reduce the npm package to only contain the `dist` folder instead of the whole set of tests, sources, gh-pages etc