### PR TITLE
Make spaces between HTML attributes optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,6 @@ The full API docs for Autolinker may be referenced at:
 Pull requests definitely welcome.
 
 - Make sure to add tests to cover your new functionality/bugfix.
-- Install development dependencies via `npm install gulp -g`.
 - Run the `gulp` command to build/test (or alternatively, open the `tests/index.html` file to run the tests).
 - When committing, please omit checking in the files in the `dist/` folder after building/testing. These are only committed to the repository for users downloading Autolinker via Bower. I will build these files and assign them a version number when merging your PR.
 - Please use tabs for indents! Tabs are better for everybody (individuals can set their editors to different tab sizes based on their visual preferences).

--- a/README.md
+++ b/README.md
@@ -316,7 +316,8 @@ The full API docs for Autolinker may be referenced at:
 Pull requests definitely welcome.
 
 - Make sure to add tests to cover your new functionality/bugfix.
-- Run the `grunt` command to build/test (or alternatively, open the `tests/index.html` file to run the tests).
+- Install development dependencies via `npm install gulp -g`.
+- Run the `gulp` command to build/test (or alternatively, open the `tests/index.html` file to run the tests).
 - When committing, please omit checking in the files in the `dist/` folder after building/testing. These are only committed to the repository for users downloading Autolinker via Bower. I will build these files and assign them a version number when merging your PR.
 - Please use tabs for indents! Tabs are better for everybody (individuals can set their editors to different tab sizes based on their visual preferences).
 

--- a/src/htmlParser/HtmlParser.js
+++ b/src/htmlParser/HtmlParser.js
@@ -69,7 +69,7 @@ Autolinker.htmlParser.HtmlParser = Autolinker.Util.extend( Object, {
 
 							// Zero or more attributes following the tag name
 							'(?:',
-								'\\s+',                // one or more whitespace chars before an attribute
+								'\\s*',                // any number of whitespace chars before an attribute
 								nameEqualsValueRegex,  // attr="value" (with optional ="value" part)
 							')*',
 

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -1135,6 +1135,12 @@ describe( "Autolinker", function() {
 			} );
 
 
+			it( "should NOT automatically link an image tag with incorrect HTML attribute spacing", function() {
+				var result = autolinker.link( '<img src="https://ssl.gstatic.com/welcome_calendar.png" alt="Calendar" style="display:block;"width="129"height="129"/>' );
+				expect( result ).toBe( '<img src="https://ssl.gstatic.com/welcome_calendar.png" alt="Calendar" style="display:block;"width="129"height="129"/>' );
+			} );
+
+
 			it( "should NOT automatically link an image tag with a URL inside it, inside an anchor tag", function() {
 				var result = autolinker.link( '<a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a>' );
 				expect( result ).toBe( '<a href="http://google.com"><img src="http://google.com/someImage.jpg" /></a>' );


### PR DESCRIPTION
Fixes issue #146 with new test and tiny regexp change.

This doesn't cause any of the other tests to fail.