### PR TITLE
Allow apostrophe in email addresses

### DIFF
--- a/src/matcher/Email.js
+++ b/src/matcher/Email.js
@@ -19,7 +19,7 @@ Autolinker.matcher.Email = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 	 */
 	matcherRegex : (function() {
 		var alphaNumericChars = Autolinker.RegexLib.alphaNumericCharsStr,
-		    emailRegex = new RegExp( '[' + alphaNumericChars + '\\-;:&=+$.,]+@' ),  // something@ for email addresses (a.k.a. local-part)
+		    emailRegex = new RegExp( '[' + alphaNumericChars + '\\-\';:&=+$.,]+@' ),  // something@ for email addresses (a.k.a. local-part)
 			domainNameRegex = Autolinker.RegexLib.domainNameRegex,
 			tldRegex = Autolinker.RegexLib.tldRegex;  // match our known top level domains (TLDs)
 

--- a/tests/matcher/EmailSpec.js
+++ b/tests/matcher/EmailSpec.js
@@ -60,6 +60,14 @@ describe( "Autolinker.matcher.Email", function() {
 			MatchChecker.expectEmailMatch( matches[ 0 ], 'asdf@asdf.com', 7 );
 		} );
 
+
+		it( 'a match with an \' should be parsed correctly', function() {
+			var matches = matcher.parseMatches( 'o\'donnel@asdf.com' );
+
+			expect( matches.length ).toBe( 1 );
+			MatchChecker.expectEmailMatch( matches[ 0 ], 'o\'donnel@asdf.com', 0 );
+		} );
+
 	} );
 
 


### PR DESCRIPTION
This PR allows apostrophe to be used in email addresses, with tests. fix #162

On a related note I would remove email validation entirely if I were you, leaving the tedious job to email clients, while always linking whatever is before the `@` symbol to `domain.tld`