### PR TITLE
Change domain regex to not match domains with leading - or . characters

### DIFF
--- a/src/RegexLib.js
+++ b/src/RegexLib.js
@@ -48,9 +48,14 @@ Autolinker.RegexLib = (function() {
 	// See documentation below
 	var alphaNumericCharsStr = alphaCharsStr + decimalNumbersStr;
 
+	// Simplified IP regular expression
+	var ipRegex = new RegExp( '(?:[' + decimalNumbersStr + ']{1,3}\\.){3}[' + decimalNumbersStr + ']{1,3}' );
+
+	// Protected domain label which do not allow "-" character on the beginning and the end of a single label
+	var domainLabelStr = '[' + alphaNumericCharsStr + '](?:[' + alphaNumericCharsStr + '\\-]*[' + alphaNumericCharsStr + '])?';
 
 	// See documentation below
-	var domainNameRegex = new RegExp( '[' + alphaNumericCharsStr + '.\\-]*[' + alphaNumericCharsStr + '\\-]' );
+	var domainNameRegex = new RegExp( '(?:(?:(?:' + domainLabelStr + '\\.)*(?:' + domainLabelStr + '))|(?:' + ipRegex.source + '))' );
 
 	return {
 

--- a/src/matcher/Email.js
+++ b/src/matcher/Email.js
@@ -19,7 +19,11 @@ Autolinker.matcher.Email = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 	 */
 	matcherRegex : (function() {
 		var alphaNumericChars = Autolinker.RegexLib.alphaNumericCharsStr,
-		    emailRegex = new RegExp( '[' + alphaNumericChars + '\\-_\';:&=+$.,]+@' ),  // something@ for email addresses (a.k.a. local-part)
+			specialCharacters = '!#$%&\'*+\\-\\/=?^_`{|}~',
+			restrictedSpecialCharacters = '\\s"(),:;<>@\\[\\]',
+			validCharacters = alphaNumericChars + specialCharacters,
+			validRestrictedCharacters = validCharacters + restrictedSpecialCharacters,
+		    emailRegex = new RegExp( '(?:(?:[' + validCharacters + '](?![^@]*\\.\\.)(?:[' + validCharacters + '.]*[' + validCharacters + '])?)|(?:\\"[' + validRestrictedCharacters + '.]+\\"))@'),
 			domainNameRegex = Autolinker.RegexLib.domainNameRegex,
 			tldRegex = Autolinker.tldRegex;  // match our known top level domains (TLDs)
 

--- a/tests/matcher/EmailSpec.js
+++ b/tests/matcher/EmailSpec.js
@@ -76,6 +76,24 @@ describe( "Autolinker.matcher.Email", function() {
 			MatchChecker.expectEmailMatch( matches[ 0 ], 'o\'donnel@asdf.com', 0 );
 		} );
 
+		it( 'should *not* match email with incorrect domain beginning with "-"', function() {
+			var matches = matcher.parseMatches( 'asdf@-asdf.com' );
+
+			expect( matches.length ).toBe( 0 );
+		} );
+
+		it( 'should *not* match email with incorrect domain ending with "-"', function() {
+			var matches = matcher.parseMatches( 'asdf@asdf-.com' );
+
+			expect( matches.length ).toBe( 0 );
+		} );
+
+		it( 'should *not* match email with incorrect domain beginning with "."', function() {
+			var matches = matcher.parseMatches( 'asdf@.asdf.com' );
+
+			expect( matches.length ).toBe( 0 );
+		} );
+
 	} );
 
 

--- a/tests/matcher/EmailSpec.js
+++ b/tests/matcher/EmailSpec.js
@@ -94,6 +94,26 @@ describe( "Autolinker.matcher.Email", function() {
 			expect( matches.length ).toBe( 0 );
 		} );
 
+		it( 'should *not* match email with incorrect local part beginning with "."', function() {
+			var matches = matcher.parseMatches( '.asdf@asdf.com' );
+
+			expect( matches.length ).toBe( 1 );
+			MatchChecker.expectEmailMatch( matches[ 0 ], 'asdf@asdf.com', 1 );
+		} );
+
+		it( 'should *not* match email with incorrect local part ending with "."', function() {
+			var matches = matcher.parseMatches( 'asdf.@asdf.com' );
+
+			expect( matches.length ).toBe( 0 );
+		} );
+
+		it( 'should match email skipping incorrect local part tailing with ".."', function() {
+			var matches = matcher.parseMatches( 'asdf..asdf@asdf.com' );
+
+			expect( matches.length ).toBe( 1 );
+			MatchChecker.expectEmailMatch( matches[ 0 ], 'asdf@asdf.com', 6 );
+		} );
+
 	} );
 
 


### PR DESCRIPTION
According to official specifications which are summarised here http://emailregex.com/email-validation-summary/ domain labels can't be trailing or leading by "-" character. A domain can't be also leaded by "." character as it should separate two domain labels only. I've separated IP regex as well to simplify the code and added e-mail tests to cover previously failing cases.