### PR TITLE
Reduce backtracking

### DIFF
--- a/src/matcher/Email.js
+++ b/src/matcher/Email.js
@@ -23,7 +23,7 @@ Autolinker.matcher.Email = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 			restrictedSpecialCharacters = '\\s"(),:;<>@\\[\\]',
 			validCharacters = alphaNumericChars + specialCharacters,
 			validRestrictedCharacters = validCharacters + restrictedSpecialCharacters,
-		    emailRegex = new RegExp( '(?:(?:[' + validCharacters + '](?![^@]*\\.\\.)(?:[' + validCharacters + '.]*[' + validCharacters + '])?)|(?:\\"[' + validRestrictedCharacters + '.]+\\"))@'),
+		    emailRegex = new RegExp( '(?:[' + validCharacters + '](?:[' + validCharacters + ']|\\.(?!\\.|@))*|\\"[' + validRestrictedCharacters + '.]+\\")@'),
 			domainNameRegex = Autolinker.RegexLib.domainNameRegex,
 			tldRegex = Autolinker.tldRegex;  // match our known top level domains (TLDs)
 

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -2657,6 +2657,20 @@ describe( "Autolinker", function() {
 			}
 		} );
 
+
+		it( "should be able to parse a very long string", function() {
+			var testStr = (function() {
+				var t = [];
+				for (var i = 0; i < 50000; i++) {
+					t.push( ' foo' );
+				}
+				return t.join( '' );
+			})();
+
+			var result = Autolinker.link( testStr );
+			expect( result ).toBe( testStr );
+		} );
+
 	} );
 
 


### PR DESCRIPTION
The regexp in the email matcher does a lot of backtracking, making it choke on long strings.

I have tried to rewrite the regexp into an equivalent but less backtracking-prone version.