### PR TITLE
Decode percent-encoding for display

### DIFF
--- a/docs/examples/live-example/index.html
+++ b/docs/examples/live-example/index.html
@@ -41,6 +41,7 @@
 			<h4>Other Options:</h4>
 			<div id="option-stripPrefix"></div>
 			<div id="option-stripTrailingSlash"></div>
+			<div id="option-decodePercentEncoding"></div>
 			<div id="option-newWindow"></div>
 			<br>
 			<div id="option-truncate-length"></div>

--- a/docs/examples/live-example/live-example-all.js
+++ b/docs/examples/live-example/live-example-all.js
@@ -261,7 +261,7 @@ var CheckboxOption = LiveExample.CheckboxOption;
 var RadioOption = LiveExample.RadioOption;
 var TextOption = LiveExample.TextOption;
 $(document).ready(function () {
-    var $inputEl = $('#input'), $outputEl = $('#output'), $optionsOutputEl = $('#options-output'), urlsSchemeOption, urlsWwwOption, urlsTldOption, emailOption, phoneOption, mentionOption, hashtagOption, newWindowOption, stripPrefixOption, stripTrailingSlashOption, truncateLengthOption, truncationLocationOption, classNameOption;
+    var $inputEl = $('#input'), $outputEl = $('#output'), $optionsOutputEl = $('#options-output'), urlsSchemeOption, urlsWwwOption, urlsTldOption, emailOption, phoneOption, mentionOption, hashtagOption, newWindowOption, stripPrefixOption, stripTrailingSlashOption, decodePercentEncodingOption, truncateLengthOption, truncationLocationOption, classNameOption;
     init();
     function init() {
         urlsSchemeOption = new CheckboxOption({ name: 'urls.schemeMatches', description: 'Scheme:// URLs', defaultValue: true }).onChange(autolink);
@@ -274,6 +274,7 @@ $(document).ready(function () {
         newWindowOption = new CheckboxOption({ name: 'newWindow', description: 'Open in new window', defaultValue: true }).onChange(autolink);
         stripPrefixOption = new CheckboxOption({ name: 'stripPrefix', description: 'Strip prefix', defaultValue: true }).onChange(autolink);
         stripTrailingSlashOption = new CheckboxOption({ name: 'stripTrailingSlash', description: 'Strip trailing slash', defaultValue: true }).onChange(autolink);
+        decodePercentEncodingOption = new CheckboxOption({ name: 'decodePercentEncoding', description: 'Decode percent-encoding', defaultValue: true }).onChange(autolink);
         truncateLengthOption = new TextOption({ name: 'truncate.length', description: 'Truncate Length', size: 2, defaultValue: '0' }).onChange(autolink);
         truncationLocationOption = new RadioOption({ name: 'truncate.location', description: 'Truncate Location', options: ['end', 'middle', 'smart'], defaultValue: 'end' }).onChange(autolink);
         classNameOption = new TextOption({ name: 'className', description: 'CSS class(es)', size: 10 }).onChange(autolink);
@@ -302,6 +303,7 @@ $(document).ready(function () {
             newWindow: newWindowOption.getValue(),
             stripPrefix: stripPrefixOption.getValue(),
             stripTrailingSlash: stripTrailingSlashOption.getValue(),
+            decodePercentEncoding: decodePercentEncodingOption.getValue(),
             className: classNameOption.getValue(),
             truncate: {
                 length: +truncateLengthOption.getValue(),
@@ -324,6 +326,7 @@ $(document).ready(function () {
             "",
             ("    stripPrefix : " + optionsObj.stripPrefix + ","),
             ("    stripTrailingSlash : " + optionsObj.stripTrailingSlash + ","),
+            ("    decodePercentEncoding : " + optionsObj.decodePercentEncoding + ","),
             ("    newWindow   : " + optionsObj.newWindow + ","),
             "",
             "    truncate : {",

--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -121,6 +121,7 @@ var Autolinker = function( cfg ) {
 	this.newWindow = typeof cfg.newWindow === 'boolean' ? cfg.newWindow : true;
 	this.stripPrefix = this.normalizeStripPrefixCfg( cfg.stripPrefix );
 	this.stripTrailingSlash = typeof cfg.stripTrailingSlash === 'boolean' ? cfg.stripTrailingSlash : true;
+	this.decodePercentEncoding = typeof cfg.decodePercentEncoding === 'boolean' ? cfg.decodePercentEncoding : true;
 
 	// Validate the value of the `mention` cfg
 	var mention = this.mention;
@@ -351,6 +352,16 @@ Autolinker.prototype = {
 	 *
 	 *  Example when `true`: `http://google.com/` will be displayed as
 	 *  `http://google.com`.
+	 */
+
+	/**
+	 * @cfg {Boolean} [decodePercentEncoding=true]
+	 *
+	 * `true` to decode percent-encoded characters in URL matches, `false` to keep
+	 *  the percent-encoded characters.
+	 *
+	 *  Example when `true`: `https://en.wikipedia.org/wiki/San_Jos%C3%A9` will
+	 *  be displayed as `https://en.wikipedia.org/wiki/San_José`.
 	 */
 
 	/**
@@ -852,7 +863,7 @@ Autolinker.prototype = {
 				new matchersNs.Email( { tagBuilder: tagBuilder } ),
 				new matchersNs.Phone( { tagBuilder: tagBuilder } ),
 				new matchersNs.Mention( { tagBuilder: tagBuilder, serviceName: this.mention } ),
-				new matchersNs.Url( { tagBuilder: tagBuilder, stripPrefix: this.stripPrefix, stripTrailingSlash: this.stripTrailingSlash } )
+				new matchersNs.Url( { tagBuilder: tagBuilder, stripPrefix: this.stripPrefix, stripTrailingSlash: this.stripTrailingSlash, decodePercentEncoding: this.decodePercentEncoding } )
 			];
 
 			return ( this.matchers = matchers );

--- a/src/match/Url.js
+++ b/src/match/Url.js
@@ -50,6 +50,10 @@ Autolinker.match.Url = Autolinker.Util.extend( Autolinker.match.Match, {
 	 * @inheritdoc Autolinker#cfg-stripTrailingSlash
 	 */
 
+	/**
+	 * @cfg {Boolean} decodePercentEncoding (required)
+	 * @inheritdoc Autolinker#cfg-decodePercentEncoding
+	 */
 
 	/**
 	 * @constructor
@@ -66,6 +70,7 @@ Autolinker.match.Url = Autolinker.Util.extend( Autolinker.match.Match, {
 		if( cfg.protocolRelativeMatch == null ) throw new Error( '`protocolRelativeMatch` cfg required' );
 		if( cfg.stripPrefix == null ) throw new Error( '`stripPrefix` cfg required' );
 		if( cfg.stripTrailingSlash == null ) throw new Error( '`stripTrailingSlash` cfg required' );
+		if( cfg.decodePercentEncoding == null ) throw new Error( '`decodePercentEncoding` cfg required' );
 		// @endif
 
 		this.urlMatchType = cfg.urlMatchType;
@@ -74,6 +79,7 @@ Autolinker.match.Url = Autolinker.Util.extend( Autolinker.match.Match, {
 		this.protocolRelativeMatch = cfg.protocolRelativeMatch;
 		this.stripPrefix = cfg.stripPrefix;
 		this.stripTrailingSlash = cfg.stripTrailingSlash;
+		this.decodePercentEncoding = cfg.decodePercentEncoding;
 	},
 
 
@@ -192,6 +198,9 @@ Autolinker.match.Url = Autolinker.Util.extend( Autolinker.match.Match, {
 		if( this.stripTrailingSlash ) {
 			anchorText = this.removeTrailingSlash( anchorText );  // remove trailing slash, if there is one
 		}
+		if( this.decodePercentEncoding ) {
+			anchorText = this.removePercentEncoding( anchorText);
+		}
 
 		return anchorText;
 	},
@@ -254,6 +263,28 @@ Autolinker.match.Url = Autolinker.Util.extend( Autolinker.match.Match, {
 			anchorText = anchorText.slice( 0, -1 );
 		}
 		return anchorText;
+	},
+
+	/**
+	 * Decodes percent-encoded characters from the given `anchorText`, in preparation for the text to be displayed.
+	 *
+	 * @private
+	 * @param {String} anchorText The text of the anchor that is being generated, for which to decode any percent-encoded characters.
+	 * @return {String} The `anchorText`, with the percent-encoded characters decoded.
+	 */
+	removePercentEncoding : function( anchorText ) {
+		try {
+			return decodeURIComponent( anchorText
+				.replace( /%22/gi, '&quot;' )
+				.replace( /%26/gi, '&amp;' )
+				.replace( /%27/gi, '&#39;')
+				.replace( /%3C/gi, '&lt;' )
+				.replace( /%3E/gi, '&gt;' )
+			 );
+		} catch (e) {
+			// Invalid escape sequence.
+			return anchorText;
+		}
 	}
 
 } );

--- a/src/matcher/Url.js
+++ b/src/matcher/Url.js
@@ -20,6 +20,11 @@ Autolinker.matcher.Url = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 	 * @inheritdoc Autolinker#stripTrailingSlash
 	 */
 
+	/**
+	 * @cfg {Boolean} decodePercentEncoding (required)
+	 * @inheritdoc Autolinker#decodePercentEncoding
+	 */
+
 
 	/**
 	 * @private
@@ -155,6 +160,7 @@ Autolinker.matcher.Url = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 
 		this.stripPrefix = cfg.stripPrefix;
 		this.stripTrailingSlash = cfg.stripTrailingSlash;
+		this.decodePercentEncoding = cfg.decodePercentEncoding;
 	},
 
 
@@ -165,6 +171,7 @@ Autolinker.matcher.Url = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 		var matcherRegex = this.matcherRegex,
 		    stripPrefix = this.stripPrefix,
 		    stripTrailingSlash = this.stripTrailingSlash,
+		    decodePercentEncoding = this.decodePercentEncoding,
 		    tagBuilder = this.tagBuilder,
 		    matches = [],
 		    match;
@@ -227,7 +234,8 @@ Autolinker.matcher.Url = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 				protocolUrlMatch      : protocolUrlMatch,
 				protocolRelativeMatch : !!protocolRelativeMatch,
 				stripPrefix           : stripPrefix,
-				stripTrailingSlash    : stripTrailingSlash
+				stripTrailingSlash    : stripTrailingSlash,
+				decodePercentEncoding : decodePercentEncoding,
 			} ) );
 		}
 

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -762,7 +762,7 @@ describe( "Autolinker", function() {
 
 				it( "should include escaped parentheses in the URL", function() {
 					var result = autolinker.link( "Here's an example from CodingHorror: http://en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29" );
-					expect( result ).toBe( 'Here\'s an example from CodingHorror: <a href="http://en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29">en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29</a>' );
+					expect( result ).toBe( 'Here\'s an example from CodingHorror: <a href="http://en.wikipedia.org/wiki/PC_Tools_%28Central_Point_Software%29">en.wikipedia.org/wiki/PC_Tools_(Central_Point_Software)</a>' );
 				} );
 
 			} );
@@ -818,6 +818,20 @@ describe( "Autolinker", function() {
 					expect( result ).toBe( '<a href="http://google.no/maps/place/Gary\'s+Deli/@52.3664378,4.869345,18z/data=!4m7!1m4!3m3!1s0x47c609c14a6680df:0x643f005113531f15!2sBeertemple!3b1!3m1!1s0x0000000000000000:0x51a8a6adb4307be6?hl=no">google.no/maps/place/Gary\'s+Deli/@52.3664378,4.869345,18z/data=!4m7!1m4!3m3!1s0x47c609c14a6680df:0x643f005113531f15!2sBeertemple!3b1!3m1!1s0x0000000000000000:0x51a8a6adb4307be6?hl=no</a>' );
 				} );
 
+
+				it( "should decode emojis", function() {
+					var result = autolinker.link( "Danish flag emoji: https://emojipedia.org/%F0%9F%87%A9%F0%9F%87%B0" );
+
+					expect( result ).toBe( 'Danish flag emoji: <a href="https://emojipedia.org/%F0%9F%87%A9%F0%9F%87%B0">emojipedia.org/🇩🇰</a>' );
+				} );
+
+
+				it( "should HTML-encode escape-encoded special characters", function() {
+					var result = autolinker.link( "Link: http://example.com/%3c%3E%22%27%26" );
+
+					expect( result ).toBe( 'Link: <a href="http://example.com/%3c%3E%22%27%26">example.com/&lt;&gt;&quot;&#39;&amp;</a>' );
+				} );
+
 			} );
 
 
@@ -861,7 +875,7 @@ describe( "Autolinker", function() {
 
 				it( "should automatically link a URL with a complex hash (such as a Google Analytics url)", function() {
 					var result = autolinker.link( "Joe went to https://www.google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25/ and analyzed his analytics" );
-					expect( result ).toBe( 'Joe went to <a href="https://www.google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25/">google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25</a> and analyzed his analytics' );
+					expect( result ).toBe( 'Joe went to <a href="https://www.google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/%3F.date00%3D20120314%26_.date01%3D20120314%268534-table.rowStart%3D0%268534-table.rowCount%3D25/">google.com/analytics/web/?pli=1#my-reports/Obif-Y6qQB2xAJk0ZZE1Zg/a4454143w36378534p43704543/?.date00=20120314&amp;_.date01=20120314&amp;8534-table.rowStart=0&amp;8534-table.rowCount=25</a> and analyzed his analytics' );
 				} );
 
 
@@ -1729,6 +1743,7 @@ describe( "Autolinker", function() {
 				expect( result ).toBe( tobe );
 			} );
 
+
 		} );
 
 
@@ -1897,6 +1912,44 @@ describe( "Autolinker", function() {
 				} );
 
 				expect( result ).toBe( '<a href="http://google.com/">http://google.com/</a>' );
+			} );
+
+		} );
+
+
+		describe( "`decodePercentEncoding` option", function() {
+
+			it( "by default, should decode percent-encoding", function() {
+				var result = Autolinker.link( "https://en.wikipedia.org/wiki/San_Jos%C3%A9", {
+					stripPrefix : false,
+					//decodePercentEncoding : true,  -- not providing this cfg
+					newWindow   : false
+				} );
+
+				expect( result ).toBe( '<a href="https://en.wikipedia.org/wiki/San_Jos%C3%A9">https://en.wikipedia.org/wiki/San_José</a>' );
+			} );
+
+
+			it( "when provided as `true`, should decode percent-encoding", function() {
+				var result = Autolinker.link( "https://en.wikipedia.org/wiki/San_Jos%C3%A9", {
+					stripPrefix           : false,
+					decodePercentEncoding : true,
+					newWindow             : false
+				} );
+
+				expect( result ).toBe( '<a href="https://en.wikipedia.org/wiki/San_Jos%C3%A9">https://en.wikipedia.org/wiki/San_José</a>' );
+			} );
+
+
+			it( "when provided as `false`, should not decode percent-encoding",
+			function() {
+				var result = Autolinker.link( "https://en.wikipedia.org/wiki/San_Jos%C3%A9", {
+					stripPrefix           : false,
+					decodePercentEncoding : false,
+					newWindow             : false
+				} );
+
+				expect( result ).toBe( '<a href="https://en.wikipedia.org/wiki/San_Jos%C3%A9">https://en.wikipedia.org/wiki/San_Jos%C3%A9</a>' );
 			} );
 
 		} );


### PR DESCRIPTION
URLs containing percent-encoding 8-bit characters would be more readable if the percent-encoding is decoded for display (but not in the href attribute).

E.g. `https://en.wikipedia.org/wiki/San_Jos%C3%A9` would be displayed as `https://en.wikipedia.org/wiki/San_José`.

I made this option enabled by default. Users will already be accustomed to this kind of decoding from the URL field in their browser. Even though the URL field in the browser shows `https://en.wikipedia.org/wiki/San_José`, the URL being requested is `https://en.wikipedia.org/wiki/San_Jos%C3%A9`.