### PR TITLE
Fix #204 Use regex atomic groups for attr matching

### DIFF
--- a/tests/htmlParser/HtmlParserSpec.js
+++ b/tests/htmlParser/HtmlParserSpec.js
@@ -309,4 +309,12 @@ describe( "Autolinker.htmlParser.HtmlParser", function() {
 		expectTextNode( nodes[ 0 ], 0, inputStr );
 	} );
 
+	it( "should not freeze up the regular expression engine when presented with the input string in issue #204", function() {
+		var inputStr = '<img src="http://example.com/Foo" border-radius:2px;moz-border-radius:2px;khtml-border-radius:2px;o-border-radius:2px;webkit-border-radius:2px;ms-border-radius:="" 2px; "=" " class=" ">',
+		    nodes = htmlParser.parse( inputStr );
+
+		expect( nodes.length ).toBe( 1 );
+		expectTextNode( nodes[ 0 ], 0, inputStr );
+	} );
+
 } );


### PR DESCRIPTION
I tracked down the source of [this issue](https://github.com/gregjacobs/Autolinker.js/issues/204) to this line:

```js
attrNameRegex = /[^\s"'>\/=\x00-\x1F\x7F]+/,
```

After some googling I landed on [this SO question](https://stackoverflow.com/questions/17116675/why-does-this-regex-make-chrome-hang) that enlightened me on "catastrophic backtracking", which seemed to be happening on this line. [Another SO post](https://stackoverflow.com/questions/12841970/how-can-i-recognize-an-evil-regex/) suggested using RegEx atomic groups to prevent this from happening. JavaScript doesn't have first class support for atomic groups (`(?>foo)`) but the same result can be achieved with this pattern `(?=(foo))\n` where `n` is the capture group number (courtesy of [this page](http://instanceof.me/post/52245507631/regex-emulate-atomic-grouping-with-lookahead)).

If you run the test I added in Chrome or Firefox (Safari seems to handle this fine), the page will freeze. After my atomic group addition, the page runs fine.