### PR TITLE
International (non-US) Phone Numbers

### DIFF
--- a/src/matcher/Phone.js
+++ b/src/matcher/Phone.js
@@ -40,7 +40,7 @@ Autolinker.matcher.Phone = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 			// Remove non-numeric values from phone number string
 			var matchedText = match[0],
 				cleanNumber = matchedText.replace(/[^0-9,;#]/g, ''), // strip out non-digit characters exclude comma semicolon and #
-				plusSign = !!(match[1] || match[2]), // match[ 1 ] or match[ 3 ] is the prefixed plus sign, if there is one
+				plusSign = !!(match[1] || match[2]), // match[ 1 ] or match[ 2 ] is the prefixed plus sign, if there is one
 				before = match.index == 0 ? '' : text.substr(match.index - 1, 1),
 				after = text.substr(match.index + matchedText.length, 1),
 				contextClear = !before.match(/\d/) && !after.match(/\d/);

--- a/src/matcher/Phone.js
+++ b/src/matcher/Phone.js
@@ -45,7 +45,7 @@ Autolinker.matcher.Phone = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 				after = text.substr(match.index + matchedText.length, 1),
 				contextClear = !before.match(/\d/) && !after.match(/\d/);
 
-			if (this.testMatch(match[4]) && this.testMatch(matchedText) && contextClear) {
+			if (this.testMatch(match[3]) && this.testMatch(matchedText) && contextClear) {
 				matches.push(new Autolinker.match.Phone({
 					tagBuilder: tagBuilder,
 					matchedText: matchedText,

--- a/src/matcher/Phone.js
+++ b/src/matcher/Phone.js
@@ -17,15 +17,15 @@ Autolinker.matcher.Phone = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 	 *
 	 * This regular expression has the following capturing groups:
 	 *
-	 * 1. The prefixed '+' sign, if there is one.
+	 * 1 or 2. The prefixed '+' sign, if there is one.
 	 *
 	 * @private
 	 * @property {RegExp} matcherRegex
 	 */
-    matcherRegex : /(?:(\+)?\d{1,3}[-\040.]?)?\(?\d{3}\)?[-\040.]?\d{3}[-\040.]?\d{4}([,;]*[0-9]+#?)*/g,    
-    
-    // ex: (123) 456-7890, 123 456 7890, 123-456-7890, +18004441234,,;,10226420346#, 
-    // +1 (800) 444 1234, 10226420346#, 1-800-444-1234,1022,64,20346#
+	matcherRegex : /(?:(?:(?:(\+)?\d{1,3}[-\040.]?)?\(?\d{3}\)?[-\040.]?\d{3}[-\040.]?\d{4})|(?:(\+)(?:9[976]\d|8[987530]\d|6[987]\d|5[90]\d|42\d|3[875]\d|2[98654321]\d|9[8543210]|8[6421]|6[6543210]|5[87654321]|4[987654310]|3[9643210]|2[70]|7|1)[-\040.]?(?:\d[-\040.]?){6,12}\d+))([,;]+[0-9]+#?)*/g,
+
+	// ex: (123) 456-7890, 123 456 7890, 123-456-7890, +18004441234,,;,10226420346#,
+	// +1 (800) 444 1234, 10226420346#, 1-800-444-1234,1022,64,20346#
 
 	/**
 	 * @inheritdoc
@@ -40,16 +40,20 @@ Autolinker.matcher.Phone = Autolinker.Util.extend( Autolinker.matcher.Matcher, {
 			// Remove non-numeric values from phone number string
 			var matchedText = match[0],
 				cleanNumber = matchedText.replace(/[^0-9,;#]/g, ''), // strip out non-digit characters exclude comma semicolon and #
-				plusSign = !!match[1]; // match[ 1 ] is the prefixed plus sign, if there is one
-			if (this.testMatch(match[2]) && this.testMatch(matchedText)) {
-    			matches.push(new Autolinker.match.Phone({
-    				tagBuilder: tagBuilder,
-    				matchedText: matchedText,
-    				offset: match.index,
-    				number: cleanNumber,
-    				plusSign: plusSign
-    			}));
-            }
+				plusSign = !!(match[1] || match[2]), // match[ 1 ] or match[ 3 ] is the prefixed plus sign, if there is one
+				before = match.index == 0 ? '' : text.substr(match.index - 1, 1),
+				after = text.substr(match.index + matchedText.length, 1),
+				contextClear = !before.match(/\d/) && !after.match(/\d/);
+
+			if (this.testMatch(match[4]) && this.testMatch(matchedText) && contextClear) {
+				matches.push(new Autolinker.match.Phone({
+					tagBuilder: tagBuilder,
+					matchedText: matchedText,
+					offset: match.index,
+					number: cleanNumber,
+					plusSign: plusSign
+				}));
+			}
 		}
 
 		return matches;

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -1107,6 +1107,10 @@ describe( "Autolinker", function() {
 				expect( autolinker.link( "1-541-754-3010" ) ).toBe(   '<a href="tel:15417543010">1-541-754-3010</a>' );
 				expect( autolinker.link( "1 (541) 754-3010" ) ).toBe( '<a href="tel:15417543010">1 (541) 754-3010</a>' );
 				expect( autolinker.link( "1.541.754.3010" ) ).toBe(   '<a href="tel:15417543010">1.541.754.3010</a>' );
+				expect( autolinker.link( "+43 5 1766 1000" ) ).toBe(  '<a href="tel:+43517661000">+43 5 1766 1000</a>' );
+				expect( autolinker.link( "+381 38 502 456" ) ).toBe(   '<a href="tel:+38138502456">+381 38 502 456</a>' );
+				expect( autolinker.link( "+38755233976" ) ).toBe( '<a href="tel:+38755233976">+38755233976</a>' );
+				expect( autolinker.link( "+852 2846 6433" ) ).toBe(   '<a href="tel:+85228466433">+852 2846 6433</a>' );
 			} );
 
 
@@ -2807,7 +2811,7 @@ describe( "Autolinker", function() {
 					mention : 'twitter'
 				} );
 
-				expect( matches.length ).toBe( 9 );
+				expect( matches.length ).toBe( 8 );
 
 				expect( matches[ 0 ].getType() ).toBe( 'phone' );
 				expect( matches[ 0 ].getNumber() ).toBe( '91234567' );


### PR DESCRIPTION
This PR adds support for non-US phone numbers when prefixed by a plus sign. I used [this](https://www.austrian.com/Info/Flightinformation/Worldwide%20Numbers%20Travel%20Alerts.aspx?cc=US) list for testing purposes; before this work, Autolinker only linked three of those. Now it links all but one (Montenegro is formatted incorrectly).

Additionally, this work increases the pickiness of the matcher such that a potential match will never be linked if it is followed immediately by more numbers. (This functionality was already present for extensions, but I don't believe there's any reason to limit it to those; open to hearing otherwise. This is the reason for the change from 9 matches to 8 in the custom regex test.)

Added tests for a few newly-supported numbers; all tests are passing. Please let me know if there are any questions about this PR.