### PR TITLE
Update compactMatches logic to allow multiple matches

### DIFF
--- a/src/Autolinker.js
+++ b/src/Autolinker.js
@@ -667,7 +667,7 @@ Autolinker.prototype = {
 				}
 
 				// Remove subsequent matches that overlap with the current match
-				if( matches[ i + 1 ].getOffset() <= endIdx ) {
+				if( matches[ i + 1 ].getOffset() < endIdx ) {
 					matches.splice( i + 1, 1 );
 				}
 			}

--- a/tests/AutolinkerSpec.js
+++ b/tests/AutolinkerSpec.js
@@ -1759,6 +1759,15 @@ describe( "Autolinker", function() {
 			} );
 
 
+			it( "should parse joined matchers", function() {
+				var html = "+1123123123http://google.com";
+				var tobe = "<a href=\"tel:+1123123123\">+1123123123</a><a href=\"http://google.com\">google.com</a>";
+
+				var result = autolinker.link( html );
+				expect( result ).toBe( tobe );
+			} );
+
+
 		} );
 
 


### PR DESCRIPTION
- This fixes compactMatches logic to allow matches that are right to another
- Allowing eg. `+1123123123http://google.com` to be parsed as two separate links, instead of just the first one (see the test).
- We're using Autolinker with a custom matcher that'd wrap strings like `{{tag1}}` with the HTML tag. Currently, if you put these tags one after another, Autolinker would omit every second tag. Instead of `<a>{{tag1}}</a><a>{{tag2}}</a><a>{{tag3}}</a>` we would receive `<a>{{tag1}}</a>{{tag2}}<a>{{tag3}}</a>`