### PR TITLE
feat(): add TikTok mentions and hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So, this utility attempts to handle everything. It:
 - Will properly handle URLs with query parameters or a named anchor (i.e. hash)
 - Will autolink email addresses.
 - Will autolink phone numbers.
-- Will autolink mentions (Twitter, Instagram, Soundcloud).
+- Will autolink mentions (Twitter, Instagram, Soundcloud, TikTok).
 - Will autolink hashtags.
 - Will properly handle HTML input. The utility will not change the `href`
   attribute inside anchor (&lt;a&gt;) tags (or any other tag/attribute), 
@@ -161,12 +161,12 @@ These include:
 
 - [mention](http://gregjacobs.github.io/Autolinker.js/api/#!/api/Autolinker-cfg-mention) : string<br />
   A string for the service name to have mentions (@username) auto-linked to. Supported
-  values at this time are 'twitter', 'soundcloud' and 'instagram'. Pass `false` to skip
+  values at this time are 'twitter', 'soundcloud', 'instagram' and 'tiktok'. Pass `false` to skip
   auto-linking of mentions. Defaults to `false`.
 
 - [hashtag](http://gregjacobs.github.io/Autolinker.js/api/#!/api/Autolinker-cfg-hashtag) : boolean/string<br />
   A string for the service name to have hashtags auto-linked to. Supported
-  values at this time are 'twitter', 'facebook' and 'instagram'. Pass `false` to skip
+  values at this time are 'twitter', 'facebook', 'instagram' and 'tiktok'. Pass `false` to skip
   auto-linking of hashtags. Defaults to `false`.
 
 - [stripPrefix](http://gregjacobs.github.io/Autolinker.js/api/#!/api/Autolinker-cfg-stripPrefix) : boolean<br />

--- a/docs/api/source/hashtag-match.html
+++ b/docs/api/source/hashtag-match.html
@@ -96,6 +96,8 @@ var HashtagMatch =  (function (_super) {
                 return &#39;https://www.facebook.com/hashtag/&#39; + hashtag;
             case &#39;instagram&#39;:
                 return &#39;https://instagram.com/explore/tags/&#39; + hashtag;
+			case &#39;tiktok&#39;:
+                return &#39;https://www.tiktok.com/tag/&#39; + hashtag;
             default: // Shouldn&#39;t happen because Autolinker&#39;s constructor should block any invalid values, but just in case.
                 throw new Error(&#39;Unknown service name to point hashtag to: &#39; + serviceName);
         }

--- a/docs/api/source/mention-match.html
+++ b/docs/api/source/mention-match.html
@@ -93,6 +93,8 @@ var MentionMatch =  (function (_super) {
                 return &#39;https://instagram.com/&#39; + this.mention;
             case &#39;soundcloud&#39;:
                 return &#39;https://soundcloud.com/&#39; + this.mention;
+			case &#39;instagram&#39;:
+                return &#39;https://www.tiktok.com/@&#39; + this.mention;
             default: // Shouldn&#39;t happen because Autolinker&#39;s constructor should block any invalid values, but just in case.
                 throw new Error(&#39;Unknown service name to point mention to: &#39; + this.serviceName);
         }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -1028,10 +1028,10 @@ export interface TruncateConfigObj {
 }
 
 export type HashtagConfig = false | HashtagServices;
-export type HashtagServices = 'twitter' | 'facebook' | 'instagram';
+export type HashtagServices = 'twitter' | 'facebook' | 'instagram' | 'tiktok';
 
 export type MentionConfig = false | MentionServices;
-export type MentionServices = 'twitter' | 'instagram' | 'soundcloud';
+export type MentionServices = 'twitter' | 'instagram' | 'soundcloud' | 'tiktok';
 
 export type ReplaceFn = ( match: Match ) => ReplaceFnReturn;
 export type ReplaceFnReturn = boolean | string | HtmlTag | null | undefined | void;

--- a/src/match/hashtag-match.ts
+++ b/src/match/hashtag-match.ts
@@ -89,6 +89,8 @@ export class HashtagMatch extends Match {
 				return 'https://www.facebook.com/hashtag/' + hashtag;
 			case 'instagram' :
 				return 'https://instagram.com/explore/tags/' + hashtag;
+			case 'tiktok' :
+				return 'https://www.tiktok.com/tag/' + hashtag;
 
 			default :  // Shouldn't happen because Autolinker's constructor should block any invalid values, but just in case.
 				throw new Error( 'Unknown service name to point hashtag to: ' + serviceName );

--- a/src/match/mention-match.ts
+++ b/src/match/mention-match.ts
@@ -85,6 +85,8 @@ export class MentionMatch extends Match {
 				return 'https://instagram.com/' + this.mention;
 			case 'soundcloud' :
 				return 'https://soundcloud.com/' + this.mention;
+			case 'tiktok' :
+				return 'https://www.tiktok.com/@' + this.mention;
 
 			default :  // Shouldn't happen because Autolinker's constructor should block any invalid values, but just in case.
 				throw new Error( 'Unknown service name to point mention to: ' + this.serviceName );

--- a/tests/autolinker-hashtag.spec.ts
+++ b/tests/autolinker-hashtag.spec.ts
@@ -6,11 +6,13 @@ describe( `Autolinker Hashtag Matching -`, () => {
 	const twitterAutolinker = new Autolinker( { hashtag: 'twitter', newWindow: false } );
 	const facebookAutolinker = new Autolinker( { hashtag: 'facebook', newWindow: false } );
 	const instagramAutolinker = new Autolinker( { hashtag: 'instagram', newWindow: false } );
+	const tiktokAutolinker = new Autolinker( { hashtag: 'tiktok', newWindow: false } );
 
 	const services = [
 		{ serviceName: 'twitter', urlPrefix: 'https://twitter.com/hashtag', autolinker: twitterAutolinker },
 		{ serviceName: 'instagram', urlPrefix: 'https://instagram.com/explore/tags', autolinker: instagramAutolinker },
 		{ serviceName: 'facebook', urlPrefix: 'https://www.facebook.com/hashtag', autolinker: facebookAutolinker },
+		{ serviceName: 'tiktok', urlPrefix: 'https://www.tiktok.com/tag', autolinker: tiktokAutolinker },
 	];
 
 

--- a/tests/autolinker-mention.spec.ts
+++ b/tests/autolinker-mention.spec.ts
@@ -5,11 +5,13 @@ describe( "Autolinker Mention Matching -", () => {
 	const twitterAutolinker = new Autolinker( { mention: 'twitter', newWindow: false } )
 	const instagramAutolinker = new Autolinker( { mention: 'instagram', newWindow: false } );
 	const soundcloudAutolinker = new Autolinker( { mention: 'soundcloud', newWindow: false } );
+	const tiktokAutolinker = new Autolinker( { mention: 'soundcloud', newWindow: false } );
 
 	const services = [
 		{ serviceName: 'twitter', urlPrefix: 'https://twitter.com', autolinker: twitterAutolinker },
 		{ serviceName: 'instagram', urlPrefix: 'https://instagram.com', autolinker: instagramAutolinker },
 		{ serviceName: 'soundcloud', urlPrefix: 'https://soundcloud.com', autolinker: soundcloudAutolinker },
+		{ serviceName: 'tiktok', urlPrefix: 'https://www.tiktok.com/@', autolinker: tiktokAutolinker },
 	];
 
 	it( `should not autolink mentions by default`, () => {
@@ -211,6 +213,25 @@ describe( "Autolinker Mention Matching -", () => {
 			const result = soundcloudAutolinker.link( `Hello @asdf.defg` );
 
 			expect( result ).toBe( `Hello <a href="https://soundcloud.com/asdf.defg">@asdf.defg</a>` );
+		} );
+
+	} );
+
+	describe( 'tiktok-specific tests', () => {
+
+		it( 'should link a tiktok mention that is up to 24 characters long', () => {
+			const aUsername = _.repeat( 'a', 24 );
+			const bUsername = _.repeat( 'b', 25 );  // too long - don't link
+
+			const result = tiktokAutolinker.link( `@${aUsername} and @${bUsername}` );
+			expect( result ).toBe( `<a href="https://www.tiktok.com/@${aUsername}">@${aUsername}</a> and @${bUsername}` );
+		} );
+
+
+		it( `should link a tiktok mention that has a period in it`, () => {
+			const result = tiktokAutolinker.link( `Hello @asdf.defg` );
+
+			expect( result ).toBe( `Hello <a href="https://www.tiktok.com/@asdf.defg">@asdf.defg</a>` );
 		} );
 
 	} );

--- a/tests/autolinker.spec.ts
+++ b/tests/autolinker.spec.ts
@@ -917,6 +917,9 @@ describe( "Autolinker", function() {
 
 				result = Autolinker.link( "hi from @iggypopschest", { newWindow: false, mention: 'instagram', className: 'myLink' } );
 				expect( result ).toBe( 'hi from <a href="https://instagram.com/iggypopschest" class="myLink myLink-mention myLink-instagram">@iggypopschest</a>' );
+
+				result = Autolinker.link( "hi from @iggypopschest", { newWindow: false, mention: 'tiktok', className: 'myLink' } );
+				expect( result ).toBe( 'hi from <a href="https://www.tiktok.com/@iggypopschest" class="myLink myLink-mention myLink-instagram">@iggypopschest</a>' );
 			} );
 
 		} );


### PR DESCRIPTION
TikTok has also fixed url for:

- hashtags `https://www.tiktok.com/tag/` + hashtag
- mentions `https://www.tiktok.com/@` + mention

So we could add this functionality to support this network too.