### PR TITLE
Added an underscore to allowed domain label symbols

### DIFF
--- a/src/regex-lib.ts
+++ b/src/regex-lib.ts
@@ -69,8 +69,9 @@ export const alphaCharsStr = /A-Za-z\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u0
  * The string form of a regular expression that would match all emoji characters
  * Based on the emoji regex defined in this article: https://thekevinscott.com/emojis-in-javascript/
  */
-export const emojiStr = /\u2700-\u27bf\udde6-\uddff\ud800-\udbff\udc00-\udfff\ufe0e\ufe0f\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0\ud83c\udffb-\udfff\u200d\u3299\u3297\u303d\u3030\u24c2\ud83c\udd70-\udd71\udd7e-\udd7f\udd8e\udd91-\udd9a\udde6-\uddff\ude01-\ude02\ude1a\ude2f\ude32-\ude3a\ude50-\ude51\u203c\u2049\u25aa-\u25ab\u25b6\u25c0\u25fb-\u25fe\u00a9\u00ae\u2122\u2139\udc04\u2600-\u26FF\u2b05\u2b06\u2b07\u2b1b\u2b1c\u2b50\u2b55\u231a\u231b\u2328\u23cf\u23e9-\u23f3\u23f8-\u23fa\udccf\u2935\u2934\u2190-\u21ff/
-    .source;
+export const emojiStr =
+    /\u2700-\u27bf\udde6-\uddff\ud800-\udbff\udc00-\udfff\ufe0e\ufe0f\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0\ud83c\udffb-\udfff\u200d\u3299\u3297\u303d\u3030\u24c2\ud83c\udd70-\udd71\udd7e-\udd7f\udd8e\udd91-\udd9a\udde6-\uddff\ude01-\ude02\ude1a\ude2f\ude32-\ude3a\ude50-\ude51\u203c\u2049\u25aa-\u25ab\u25b6\u25c0\u25fb-\u25fe\u00a9\u00ae\u2122\u2139\udc04\u2600-\u26FF\u2b05\u2b06\u2b07\u2b1b\u2b1c\u2b50\u2b55\u231a\u231b\u2328\u23cf\u23e9-\u23f3\u23f8-\u23fa\udccf\u2935\u2934\u2190-\u21ff/
+        .source;
 
 /**
  * The string form of a regular expression that would match all of the
@@ -161,9 +162,9 @@ export const alphaNumericAndMarksCharsStr = alphaCharsAndMarksStr + decimalNumbe
 // Simplified IP regular expression
 const ipStr = '(?:[' + decimalNumbersStr + ']{1,3}\\.){3}[' + decimalNumbersStr + ']{1,3}';
 
-// Protected domain label which do not allow "-" character on the beginning and the end of a single label
+// Protected domain label which do not allow "-" or "_" character on the beginning and the end of a single label
 // prettier-ignore
-const domainLabelStr = '[' + alphaNumericAndMarksCharsStr + '](?:[' + alphaNumericAndMarksCharsStr + '\\-]{0,61}[' + alphaNumericAndMarksCharsStr + '])?';
+const domainLabelStr = '[' + alphaNumericAndMarksCharsStr + '](?:[' + alphaNumericAndMarksCharsStr + '\\-_]{0,61}[' + alphaNumericAndMarksCharsStr + '])?';
 
 const getDomainLabelStr = (group: number) => {
     return '(?=(' + domainLabelStr + '))\\' + group;

--- a/tests/autolinker-url.spec.ts
+++ b/tests/autolinker-url.spec.ts
@@ -307,6 +307,13 @@ describe('Autolinker Url Matching -', () => {
             );
         });
 
+        it('should match a url with underscores in domain label', function () {
+            let result = autolinker.link('https://gcs_test_env.storage.googleapis.com/file.pdf');
+            expect(result).toBe(
+                '<a href="https://gcs_test_env.storage.googleapis.com/file.pdf">gcs_test_env.storage.googleapis.com/file.pdf</a>'
+            );
+        });
+
         it('should not match local urls with numbers when NOT prefixed with http://', function () {
             let result1 = autolinker.link('localhost.local001/test');
             expect(result1).toBe('localhost.local001/test');
@@ -653,6 +660,13 @@ describe('Autolinker Url Matching -', () => {
             );
         });
 
+        it('should match a url with underscores in domain label', function () {
+            let result = autolinker.link('gcs_test_env.storage.googleapis.com/file.pdf');
+            expect(result).toBe(
+                '<a href="http://gcs_test_env.storage.googleapis.com/file.pdf">gcs_test_env.storage.googleapis.com/file.pdf</a>'
+            );
+        });
+
         it('should automatically link a URL with accented characters', function () {
             let result = autolinker.link('Joe went to mañana.com today.');
             expect(result).toBe('Joe went to <a href="http://mañana.com">mañana.com</a> today.');
@@ -678,6 +692,13 @@ describe('Autolinker Url Matching -', () => {
         it('should automatically link capitalized protocol-relative URLs', function () {
             let result = autolinker.link('Joe went to //YAHOO.COM');
             expect(result).toBe('Joe went to <a href="//YAHOO.COM">YAHOO.COM</a>');
+        });
+
+        it('should match a url with underscores in domain label', function () {
+            let result = autolinker.link('//gcs_test_env.storage.googleapis.com/file.pdf');
+            expect(result).toBe(
+                '<a href="//gcs_test_env.storage.googleapis.com/file.pdf">gcs_test_env.storage.googleapis.com/file.pdf</a>'
+            );
         });
 
         it('should NOT automatically link supposed protocol-relative URLs in the form of abc//yahoo.com, which is most likely not supposed to be interpreted as a URL', function () {


### PR DESCRIPTION
This PR adds an underscore to allowed domain label symbols. We encountered an issue with this when some of our users complained that a google cloud storage URL wasn't auto-linked properly when it had one or more underscores.

As an example, currently `https://gcs_test_env.storage.googleapis.com/file.pdf` is auto-linked as `https://gcs` link + `_test_` plaintext + `env.storage.googleapis.com/file.pdf` link.

Sidenote, the `emojiStr` change was added automatically by the prettier format-on-commit. I can remove that change if you'd like.