### PR TITLE
Add semicolon as valid email local part character

### DIFF
--- a/scripts/generate-char-utils.ts
+++ b/scripts/generate-char-utils.ts
@@ -25,7 +25,7 @@ const { srcFileContents, specFileContents } = generateCharUtils([
     ['isQuoteChar', /['"]/],
     ['isWhitespaceChar', /\s/],
     ['isAlphaNumericOrMarkChar', alphaNumericAndMarksRe /*/[\p{Letter}\p{Mark}\p{Emoji}\p{Nd}]/u*/], // sadly the unicode regexp is not working, probably because the char codes are outside the range of 0-65535 for multi-char emojis and such, but not 100% sure. Need to investigate. Using the old regexp for now instead
-    ['isValidEmailLocalPartSpecialChar', /[!#$%&'*+/=?^_`{|}~-]/], // special characters that are valid in an email address
+    ['isValidEmailLocalPartSpecialChar', /[!#$%&'*+/=?^_`{|}~;-]/], // special characters that are valid in an email address
     ['isUrlSuffixAllowedSpecialChar', /[-+&@#/%=~_()|'$*[\]{}\u2713]/], // The set of characters that are allowed in the URL suffix (i.e. the path, query, and hash part of the URL) which may also form the ending character of the URL. The isUrlSuffixNotAllowedAsFinalChar() function allows for additional allowed URL suffix characters, but (generally) should not be the *last* character of a URL.
     ['isUrlSuffixNotAllowedAsFinalChar', /[?!:,.;^]/], // URL suffix characters (i.e. path, query, and has part of the URL) that are not allowed as the *last character* in the URL suffix as they would normally form the end of a sentence. The isUrlSuffixAllowedSpecialChar() function contains additional allowed URL suffix characters which are allowed as the last character.
     ['isOpenBraceChar', /[({[]/],

--- a/src/char-utils.ts
+++ b/src/char-utils.ts
@@ -93,7 +93,7 @@ export function isAlphaNumericOrMarkChar(c: number): boolean {
 }
 
 /**
- * Determines if the given character `c` matches the regular expression /[!#$%&'*+/=?^_`{|}~-]/ 
+ * Determines if the given character `c` matches the regular expression /[!#$%&'*+/=?^_`{|}~;-]/ 
  * by checking it via character code in a binary search fashion.
  * 
  * This technique speeds this function up by a factor of ~10x vs. running RegExp.prototype.test() 
@@ -104,7 +104,7 @@ export function isAlphaNumericOrMarkChar(c: number): boolean {
  *     npm run generate-char-utils
  */
 export function isValidEmailLocalPartSpecialChar(c: number): boolean {
-    return (c < 47 ? (c < 42 ? (c == 33 || (c >= 35 && c <= 39)) : ((c >= 42 && c <= 43) || c == 45)) : (c < 63 ? (c == 47 || c == 61) : (c < 94 ? c == 63 : ((c >= 94 && c <= 96) || (c >= 123 && c <= 126)))));
+    return (c < 59 ? (c < 42 ? (c == 33 || (c >= 35 && c <= 39)) : (c < 45 ? (c >= 42 && c <= 43) : (c == 45 || c == 47))) : (c < 63 ? (c == 59 || c == 61) : (c < 94 ? c == 63 : ((c >= 94 && c <= 96) || (c >= 123 && c <= 126)))));
 }
 
 /**

--- a/tests/char-utils.spec.ts
+++ b/tests/char-utils.spec.ts
@@ -78,11 +78,11 @@ describe('isAlphaNumericOrMarkChar()', () => {
 });
 
 describe('isValidEmailLocalPartSpecialChar()', () => {
-    it(`should appropriately return true/false to match the regular expression /[!#$%&'*+/=?^_\`{|}~-]/`, () => {
+    it(`should appropriately return true/false to match the regular expression /[!#$%&'*+/=?^_\`{|}~;-]/`, () => {
         for (let charCode = 0; charCode < 65535; charCode++) {
             const char = String.fromCharCode(charCode);
             const fnResult = isValidEmailLocalPartSpecialChar(charCode);
-            const regExpResult = /[!#$%&'*+/=?^_`{|}~-]/.test(char);
+            const regExpResult = /[!#$%&'*+/=?^_`{|}~;-]/.test(char);
 
             expect(fnResult).to.equal(regExpResult, `Expected charCode ${charCode} (${char}) to return ${regExpResult}, but returned ${fnResult}`);
         }


### PR DESCRIPTION
Allows email addresses containing HTML entities (e.g. &#xF6;) to be fully matched instead of being split at the semicolon.

Resolves #393